### PR TITLE
feat: add marketplace manifest for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "kb-cc-plugin",
+  "owner": {
+    "name": "LeeKangbok"
+  },
+  "metadata": {
+    "description": "Personal Claude Code plugin marketplace"
+  },
+  "plugins": [
+    {
+      "name": "error-reporter",
+      "source": "./error-reporter",
+      "description": "Reads hook debug logs and creates GitHub issues when fail events occur"
+    },
+    {
+      "name": "dashboard",
+      "source": "./dashboard",
+      "description": "Forwards all Claude Code hook events to a dashboard TUI via Unix socket"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- `.claude-plugin/marketplace.json` 추가하여 리포를 Claude Code 플러그인 마켓플레이스로 등록
- `error-reporter`, `dashboard` 2개 플러그인을 marketplace 카탈로그에 등록
- `claude plugin validate .` 검증 통과 완료

## Usage
```shell
/plugin marketplace add pmmm114/kb-cc-plugin
/plugin install error-reporter@kb-cc-plugin
/plugin install dashboard@kb-cc-plugin
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)