### PR TITLE
fix(dashboard): add required type and title to userConfig schema

### DIFF
--- a/dashboard/.claude-plugin/plugin.json
+++ b/dashboard/.claude-plugin/plugin.json
@@ -4,7 +4,9 @@
   "description": "Forwards all Claude Code hook events to a dashboard TUI via Unix socket",
   "userConfig": {
     "socket_path": {
+      "title": "Socket Path",
       "description": "Path to the Unix socket the TUI listens on (default: /tmp/claude-dashboard.sock)",
+      "type": "string",
       "sensitive": false
     }
   }


### PR DESCRIPTION
## Summary
- dashboard plugin.json의 userConfig.socket_path에 필수 필드 `type`, `title` 추가
- 플러그인 설치 시 validation 에러 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)