### PR TITLE
refactor(error-reporter): redesign as raw data reporter

### DIFF
--- a/error-reporter/.claude-plugin/plugin.json
+++ b/error-reporter/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "error-reporter",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Reads hook debug logs and creates GitHub issues when fail events occur"
 }

--- a/error-reporter/README.md
+++ b/error-reporter/README.md
@@ -49,13 +49,13 @@ Layer 1의 로그를 읽고, fail 이벤트 감지 시 GitHub Issue를 생성합
 Title 형식:
 
 ```
-[harness-debug] EVENT (session_id_8)
+[harness-debug] EVENT(agent_id) (session_id_8)
 ```
 
 예시:
 
 ```
-[harness-debug] SubagentStop (a1b2c3d4)
+[harness-debug] SubagentStop(tdd-implementer) (a1b2c3d4)
 ```
 
 Issue body 구조 (raw data — 파싱/해석 없음):

--- a/error-reporter/README.md
+++ b/error-reporter/README.md
@@ -12,7 +12,7 @@ Hook debug log를 분석하여 fail 이벤트 발생 시 error stack을 GitHub I
 
 - **로그 위치**: `/tmp/claude-debug/<session_id>.jsonl`
 - **로그 포맷**: JSONL (한 줄 = 한 결정)
-- **필드**: `ts`, `event`, `hook`, `decision`, `reason`, `phase`, `wf_id`, `session`
+- **필드**: `ts`, `event`, `hook`, `decision`, `reason`, `phase`, `wf_id`, `session`, `agent_id`
 - **Decision 유형**: `allow`, `block`, `deny`, `guide`
 - **Ring buffer**: 1000줄 초과 시 500줄로 자동 트림
 - **정리**: SessionEnd 시 자동 삭제 (`state-recovery.sh`)
@@ -26,6 +26,7 @@ Hook debug log를 분석하여 fail 이벤트 발생 시 error stack을 GitHub I
 ### Layer 2: Error Reporter (this plugin)
 
 Layer 1의 로그를 읽고, fail 이벤트 감지 시 GitHub Issue를 생성합니다.
+**Raw Data Reporter** — state.json을 파싱하지 않고 원본 그대로 적재합니다. 해석은 이슈를 읽는 사람이 수행합니다.
 
 **실행 모델**: Synchronous snapshot → Background fork → Immediate exit 0
 
@@ -39,7 +40,7 @@ Layer 1의 로그를 읽고, fail 이벤트 감지 시 GitHub Issue를 생성합
 
 | Event | Threshold | 설명 |
 |-------|-----------|------|
-| `StopFailure` | 없음 (항상 리포트) | API 에러, rate limit 등 |
+| `StopFailure` | 없음 (항상 리포트) | API 에러. `rate_limit`, `server_error`는 transient로 필터링 (이슈 미생성) |
 | `Stop` | block/deny 1회 이상 | 세션 내 에러 패턴 감지 |
 | `SubagentStop` | block/deny 1회 이상 | 에이전트 실패 감지 (agent_id 스코프 필터링) |
 
@@ -48,22 +49,21 @@ Layer 1의 로그를 읽고, fail 이벤트 감지 시 GitHub Issue를 생성합
 Title 형식:
 
 ```
-[harness-debug] EVENT(agent_id) in phase:PHASE (wf#ID)
+[harness-debug] EVENT (session_id_8)
 ```
 
 예시:
 
 ```
-[harness-debug] SubagentStop(tdd-implementer) in phase:implementing (wf#3)
+[harness-debug] SubagentStop (a1b2c3d4)
 ```
 
-Issue body 구조:
+Issue body 구조 (raw data — 파싱/해석 없음):
 
-- **Header**: Session, Trigger, Phase, Workflow, Agent, Is Subagent, Time, State age
-- **Blocked Actions**: allow 제외 전체 (block/deny/guide) 필터링, 최신 순 (causality chain), 최대 50개
-- **Config Context**: Blocking hooks 목록 (어떤 훅이 block/deny를 발생시켰는지)
-- **Full Trace**: 최근 50개 프레임 (allow 포함)
-- **Surrounding Context**: Transcript에서 assistant 역할 메시지 추출 (최대 30줄), 실패 시 tail -20 fallback
+- **Raw State**: `state.json` 원본 전체 (JSON)
+- **Debug Log (last 50)**: debug log 마지막 50줄
+- **Transcript (last 20 lines)**: transcript 마지막 20줄
+- **Hook Input**: hook event input JSON 원본
 
 ## Prerequisites
 

--- a/error-reporter/scripts/report.sh
+++ b/error-reporter/scripts/report.sh
@@ -19,7 +19,6 @@ LOG_FILE="/tmp/claude-debug/$SESSION.jsonl"
 STATE_FILE="/tmp/claude-session/$SESSION.json"
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // ""')
 AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // ""')
-IS_SUBAGENT=$(echo "$INPUT" | jq -r '.is_subagent // false')
 
 # --- Pre-flight: check if debug log exists ---
 HAS_LOG=false
@@ -62,7 +61,7 @@ TRANSCRIPT_TAIL=""
   mkdir "/tmp/claude-report-${SESSION}.lock" 2>/dev/null || exit 0
   trap 'rmdir "/tmp/claude-report-${SESSION}.lock" 2>/dev/null' EXIT
 
-  TITLE="[harness-debug] $EVENT (${SESSION:0:8})"
+  TITLE="[harness-debug] $EVENT${AGENT_ID:+($AGENT_ID)} (${SESSION:0:8})"
 
   REPORT_BODY="## Raw State
 \`\`\`json

--- a/error-reporter/scripts/report.sh
+++ b/error-reporter/scripts/report.sh
@@ -28,7 +28,9 @@ HAS_LOG=false
 # --- Threshold checks per event ---
 case "$EVENT" in
   StopFailure)
-    # Always report API errors — no threshold, proceeds even without log
+    # Filter transient errors — not harness bugs, just provider-side noise
+    SF_ERROR=$(echo "$INPUT" | jq -r '.error // ""')
+    case "$SF_ERROR" in rate_limit|server_error) exit 0 ;; esac
     ;;
   Stop)
     [ "$HAS_LOG" != true ] && exit 0
@@ -50,77 +52,37 @@ case "$EVENT" in
 esac
 
 # === Phase 1: Synchronous snapshot (fast, file reads only) ===
-STACK_RAW=$(cat "$LOG_FILE" 2>/dev/null)
 STATE_SNAPSHOT=$(cat "$STATE_FILE" 2>/dev/null || echo '{}')
-
-STATE_AGE="n/a"
-if [ -f "$STATE_FILE" ]; then
-  STATE_MTIME=$(stat -f%m "$STATE_FILE" 2>/dev/null)
-  [ -n "$STATE_MTIME" ] && STATE_AGE="$(( $(date +%s) - STATE_MTIME ))s"
-fi
-
-BLOCKING_HOOKS=""
-if [ "$HAS_LOG" = true ]; then
-  BLOCKING_HOOKS=$(jq -r 'select(.decision != "allow") | .hook' "$LOG_FILE" 2>/dev/null | sort -u | paste -sd ", " -)
-fi
-
+DEBUG_LOG_TAIL=$(tail -50 "$LOG_FILE" 2>/dev/null)
 TRANSCRIPT_TAIL=""
-if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
-  TRANSCRIPT_TAIL=$(jq -r 'select(.role == "assistant") | .content' "$TRANSCRIPT" 2>/dev/null | tail -30)
-  [ -z "$TRANSCRIPT_TAIL" ] && TRANSCRIPT_TAIL=$(tail -20 "$TRANSCRIPT" 2>/dev/null)
-fi
-
-ERROR_INFO=""
-if [ "$EVENT" = "StopFailure" ]; then
-  ERROR_INFO=$(echo "$INPUT" | jq -r '"**Error**: " + (.error // "unknown") + " — " + (.error_details // "no details")' 2>/dev/null)
-fi
-
-PHASE=$(echo "$STATE_SNAPSHOT" | jq -r '.phase // "unknown"' 2>/dev/null)
-WF_ID=$(echo "$STATE_SNAPSHOT" | jq -r '.workflow_id // 0' 2>/dev/null)
+[ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] && TRANSCRIPT_TAIL=$(tail -20 "$TRANSCRIPT" 2>/dev/null)
 
 # === Phase 2: Fork to background — all network I/O happens here ===
 (
   mkdir "/tmp/claude-report-${SESSION}.lock" 2>/dev/null || exit 0
   trap 'rmdir "/tmp/claude-report-${SESSION}.lock" 2>/dev/null' EXIT
 
-  # Build error stack: filter to current workflow, most recent first
-  ERROR_STACK=$(echo "$STACK_RAW" \
-    | jq -r 'select(.decision != "allow") | "[" + .ts + "] " + .hook + "  " + .event + "  phase:" + .phase + "  " + .decision + ": " + (.reason // "")' 2>/dev/null \
-    | tail -50 \
-    | tac 2>/dev/null || tail -r 2>/dev/null)
+  TITLE="[harness-debug] $EVENT (${SESSION:0:8})"
 
-  # Full trace (including allows) for context
-  FULL_TRACE=$(echo "$STACK_RAW" \
-    | jq -r '"[" + .ts + "] " + .hook + "  " + .decision' 2>/dev/null \
-    | tail -50)
-
-  REPORT_BODY="## Harness Debug Report
-
-**Session**: \`$SESSION\` | **Trigger**: $EVENT | **Phase**: $PHASE | **Workflow**: #$WF_ID
-**Agent**: ${AGENT_ID:-(main)} | **Is Subagent**: $IS_SUBAGENT | **Time**: $(date -u +%Y-%m-%dT%H:%M:%SZ) | **State age**: $STATE_AGE
-
-${ERROR_INFO:+$ERROR_INFO
-
-}### Blocked Actions
-Most recent non-allow decisions — read bottom-up for causality chain.
-\`\`\`
-$ERROR_STACK
+  REPORT_BODY="## Raw State
+\`\`\`json
+${STATE_SNAPSHOT:-(unavailable)}
 \`\`\`
 
-### Config Context
-- **Blocking hooks**: ${BLOCKING_HOOKS:-(none)}
-
-### Full Trace (last 50 frames)
+## Debug Log (last 50)
 \`\`\`
-$FULL_TRACE
+${DEBUG_LOG_TAIL:-(unavailable)}
 \`\`\`
 
-### Surrounding Context
+## Transcript (last 20 lines)
 \`\`\`
 ${TRANSCRIPT_TAIL:-(unavailable)}
-\`\`\`"
+\`\`\`
 
-  TITLE="[harness-debug] $EVENT${AGENT_ID:+($AGENT_ID)} in phase:$PHASE (wf#$WF_ID)"
+## Hook Input
+\`\`\`json
+$INPUT
+\`\`\`"
 
   # Attempt GitHub issue creation
   if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- error-reporter를 raw data reporter로 redesign — state.json 강결합 제거
- StopFailure `rate_limit`/`server_error` transient 필터 추가
- 이슈 본문을 해석된 포맷 → raw 4섹션(Raw State, Debug Log, Transcript, Hook Input)으로 교체
- Plugin version 2.0.0 (breaking: issue format 변경)

## Motivation
PR #82에서 state.json 스키마가 flat→nested로 변경된 후 error-reporter가 미수정되어 모든 이슈에서 `phase:unknown` 발생 (#127). 근본 원인은 state.json 파싱 의존 — 파싱 자체를 제거하여 향후 스키마 변경에 면역.

## Changes
| File | Change |
|------|--------|
| `report.sh` | PHASE/WF_ID 파싱 제거, transient 필터 추가, raw body 4섹션 |
| `plugin.json` | 1.1.0 → 2.0.0 |
| `README.md` | issue format, architecture, trigger 섹션 업데이트 |

## Test plan
- [ ] StopFailure + rate_limit → exit 0 (이슈 미생성)
- [ ] StopFailure + server_error → exit 0 (이슈 미생성)
- [ ] SubagentStop + deny 1건 → 이슈 생성, raw state 포함
- [ ] Stop + block 0건 → exit 0 (이슈 미생성)
- [ ] state.json 없는 세션 → Raw State에 `{}` 표시
- [ ] debug log 없는 세션 → StopFailure만 진행, SubagentStop/Stop은 exit 0

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)