### PR TITLE
feat: migrate config hooks from claude-setup host to plugin

### DIFF
--- a/harness-engineering/hooks/config-agent-dispatch-guard.sh
+++ b/harness-engineering/hooks/config-agent-dispatch-guard.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Agent): Block config agent dispatch without /kb-cc-config
+#
+# Gates config-planner and config-editor dispatch to ensure they only run
+# inside a config workflow phase (started by /kb-cc-config skill).
+# config-guardian is already gated by config-guardian-worktree-guard.sh.
+#
+# Detection: checks tool_input.subagent_type only.
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT=$(cat)
+export HOOK_INPUT="$INPUT"
+# Source host core (state machine) + plugin config (path detection)
+source "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/hook-lib-core.sh"
+source "${CLAUDE_PLUGIN_ROOT}/hooks/hook-lib-config.sh"
+
+if is_bypass_mode; then exit 0; fi
+
+# --- Only gate config-planner and config-editor ---
+TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input // ""')
+[ -z "$TOOL_INPUT" ] || [ "$TOOL_INPUT" = "" ] && exit 0
+
+SUBAGENT_TYPE=$(echo "$TOOL_INPUT" | jq -r '.subagent_type // ""' 2>/dev/null)
+
+case "$SUBAGENT_TYPE" in
+  config-planner|config-editor) ;;
+  *) exit 0 ;;
+esac
+
+# --- Phase check: only allow in config workflow phases ---
+STATE=$(read_state)
+PHASE=$(get_phase "$STATE")
+
+case "$PHASE" in
+  config_planning|config_plan_review|config_editing|config_verifying)
+    # Valid config phase — allow dispatch
+    exit 0
+    ;;
+  *)
+    DENY_BODY="Cannot dispatch $SUBAGENT_TYPE in phase '$PHASE'."
+    DENY_BODY="$DENY_BODY Config changes require /kb-cc-config."
+    DENY_BODY="$DENY_BODY Use \`/kb-cc-config <description>\` to start a config workflow."
+    emit_deny_json "$(format_deny_message "[config-agent-dispatch-guard]" "$DENY_BODY" "rules/config.md#worktree-isolation")"
+    exit 0
+    ;;
+esac

--- a/harness-engineering/hooks/config-guardian-worktree-guard.sh
+++ b/harness-engineering/hooks/config-guardian-worktree-guard.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Agent): Enforce worktree isolation for config-guardian
+#
+# When the Agent tool is invoked to spawn config-guardian, this hook checks
+# whether the current directory is a git worktree. If not, it blocks the call
+# and instructs Claude to create a worktree first.
+#
+# Detection: checks tool_input.subagent_type only — avoids false positives
+# when other agents mention "config-guardian" in their prompt text.
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT=$(cat)
+export HOOK_INPUT="$INPUT"
+# Source host core (state machine) + plugin config (path detection)
+source "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/hook-lib-core.sh"
+source "${CLAUDE_PLUGIN_ROOT}/hooks/hook-lib-config.sh"
+
+TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input // ""')
+if [ -z "$TOOL_INPUT" ] || [ "$TOOL_INPUT" = "" ]; then
+  exit 0
+fi
+
+# Check if this Agent call targets config-guardian (subagent_type only)
+SUBAGENT_TYPE=$(echo "$TOOL_INPUT" | jq -r '.subagent_type // ""' 2>/dev/null)
+
+if ! echo "$SUBAGENT_TYPE" | grep -qi 'config-guardian'; then
+  exit 0
+fi
+
+# Verify we're inside a git worktree
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+
+if [ -z "$GIT_DIR" ]; then
+  _DENY_SUFFIX=""
+  _CURRENT_PHASE=$(read_state | jq -r '.workflow.phase // "idle"')
+  if [ "$_CURRENT_PHASE" = "config_verifying" ]; then
+    mutate_state '.workflow.phase = "config_editing"' && \
+      _DENY_SUFFIX="\n\nPhase rolled back to config_editing — fix the worktree issue and re-dispatch."
+  fi
+  emit_deny_json "$(format_deny_message "[config-guardian-worktree-guard]" "config-guardian requires a git repository. Current directory is not a git repo.\n\nNavigate to a git repository first, then create a worktree.${_DENY_SUFFIX}" "rules/config.md#worktree-isolation")"
+  exit 0
+fi
+
+# In a worktree, git-dir differs from git-common-dir
+# (e.g., git-dir = ../../.git/worktrees/foo, git-common-dir = ../../.git)
+if [ "$GIT_DIR" = "$GIT_COMMON_DIR" ] || [ "$GIT_DIR" = ".git" ]; then
+  _DENY_SUFFIX=""
+  _CURRENT_PHASE=$(read_state | jq -r '.workflow.phase // "idle"')
+  if [ "$_CURRENT_PHASE" = "config_verifying" ]; then
+    mutate_state '.workflow.phase = "config_editing"' && \
+      _DENY_SUFFIX="\n\nPhase rolled back to config_editing — fix the worktree issue and re-dispatch."
+  fi
+  emit_deny_json "$(format_deny_message "[config-guardian-worktree-guard]" "config-guardian must run inside a git worktree, not the main working tree.\n\nTo proceed:\n  1. Use EnterWorktree to create an isolated worktree\n  2. Then re-invoke config-guardian from within the worktree\n\nRationale: Each config change must be benchmarked in isolation (one change = one branch = one worktree).${_DENY_SUFFIX}" "rules/config.md#worktree-isolation")"
+  exit 0
+fi
+
+# We're in a worktree — allow the call
+exit 0

--- a/harness-engineering/hooks/config-worktree-guard.sh
+++ b/harness-engineering/hooks/config-worktree-guard.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Enforce worktree isolation for config file modifications
+#
+# Matchers: Edit|Write (file_path check), Bash (command pattern check)
+# Sources hook-lib.sh for is_config_path and is_write_to_config
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT=$(cat)
+export HOOK_INPUT="$INPUT"
+# Source host core (state machine) + plugin config (path detection)
+source "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/hook-lib-core.sh"
+source "${CLAUDE_PLUGIN_ROOT}/hooks/hook-lib-config.sh"
+
+if is_bypass_mode; then exit 0; fi
+
+# Narrow escape hatch for /kb-cc-config bootstrap operations.
+# The skill must create the worktree and set phase state BEFORE the worktree
+# exists, so the worktree guard would otherwise self-block those steps.
+# Only the specific bootstrap-critical operations are exempted:
+#   - git worktree add / git branch targeting a config/* branch
+#   - writes to session state files (/tmp/claude-session/*.json)
+# Arbitrary config-file edits are NOT exempted — this is intentionally narrow.
+if is_skill_context "kb-cc-config"; then
+  _TOOL_NAME_EARLY=$(echo "$INPUT" | jq -r '.tool_name // ""')
+  if [ "$_TOOL_NAME_EARLY" = "Bash" ]; then
+    _CMD_EARLY=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+    # git worktree add or git branch (create) targeting config/* branch.
+    # Branch deletion (-d, -D, --delete) and read-only flags (-l, --list, --show-current, -v, --verbose) are excluded.
+    if echo "$_CMD_EARLY" | grep -qE '(git[[:space:]]+worktree[[:space:]]+add|git[[:space:]]+branch)[[:space:]].*config/' && \
+       ! echo "$_CMD_EARLY" | grep -qE 'git[[:space:]]+branch[[:space:]]+(-d|-D|--delete|-l|--list|--show-current|-v|--verbose)[[:space:]]'; then
+      exit 0
+    fi
+    # Write to session state file
+    if echo "$_CMD_EARLY" | grep -qE '/tmp/claude-session/[^/]+\.json'; then
+      exit 0
+    fi
+  fi
+  # Edit/Write to session state file
+  if [ "$_TOOL_NAME_EARLY" = "Edit" ] || [ "$_TOOL_NAME_EARLY" = "Write" ]; then
+    _FILE_EARLY=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+    if echo "$_FILE_EARLY" | grep -qE '^(/private)?/tmp/claude-session/[^/]+\.json$'; then
+      exit 0
+    fi
+  fi
+fi
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
+
+# --- Determine if target is a config file ---
+TARGET_IS_CONFIG=false
+
+if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
+  FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+  if [ -n "$FILE_PATH" ] && is_config_path "$FILE_PATH"; then
+    TARGET_IS_CONFIG=true
+  fi
+elif [ "$TOOL_NAME" = "Bash" ]; then
+  # Any active skill marker (new-style or legacy /pr) means the Bash command
+  # is part of a skill workflow (e.g., `gh pr create` from /pr skill).
+  # Bypass the config-write check entirely — the narrow kb-cc-config escape
+  # hatch above still handles bootstrap ops; this is the broader skill escape.
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+  if is_skill_context any && ! is_write_to_config "$COMMAND"; then exit 0; fi
+  if is_write_to_config "$COMMAND"; then
+    TARGET_IS_CONFIG=true
+  fi
+  # Detect config worktree/branch creation outside config phases.
+  # Branch deletion (-d, -D, --delete) and read-only flags (-l, --list, --show-current, -v, --verbose) are excluded.
+  if echo "$COMMAND" | grep -qE '(git[[:space:]]+worktree[[:space:]]+add|git[[:space:]]+branch)[[:space:]].*config/' && \
+     ! echo "$COMMAND" | grep -qE 'git[[:space:]]+branch[[:space:]]+(-d|-D|--delete|-l|--list|--show-current|-v|--verbose)[[:space:]]'; then
+    STATE=$(read_state)
+    PHASE=$(get_phase "$STATE")
+    case "$PHASE" in
+      config_planning|config_plan_review|config_editing|config_verifying) ;;
+      *)
+        emit_deny_json "$(format_deny_message "[config-worktree-guard]" "Config worktree/branch creation blocked in phase '$PHASE'. Config changes require /kb-cc-config. Use \`/kb-cc-config <description>\` to start a config workflow." "rules/config.md#worktree-isolation")"
+        exit 0
+        ;;
+    esac
+  fi
+fi
+
+[ "$TARGET_IS_CONFIG" = "false" ] && exit 0
+
+# --- Config target: check worktree ---
+CWD=$(echo "$INPUT" | jq -r '.cwd // ""')
+GIT_DIR=$(git -C "$CWD" rev-parse --git-dir 2>/dev/null)
+GIT_COMMON_DIR=$(git -C "$CWD" rev-parse --git-common-dir 2>/dev/null)
+
+if [ -z "$GIT_DIR" ]; then
+  emit_deny_json "$(format_deny_message "[config-worktree-guard]" "Config file modification blocked. Not inside a git repository.\n\nTo proceed:\n  1. git branch config/<domain>-<name> main\n  2. git worktree add /tmp/claude-config-<name> config/<domain>-<name>\n  3. Work inside the worktree directory" "rules/config.md#worktree-isolation")"
+  exit 0
+fi
+
+if [ "$GIT_DIR" = "$GIT_COMMON_DIR" ] || [ "$GIT_DIR" = ".git" ]; then
+  emit_deny_json "$(format_deny_message "[config-worktree-guard]" "Config file modification blocked in main working tree.\n\nConfig changes must be made in a dedicated worktree.\n\nTo proceed:\n  1. git branch config/<domain>-<name> main\n  2. git worktree add /tmp/claude-config-<name> config/<domain>-<name>\n  3. Work inside the worktree directory" "rules/config.md#worktree-isolation")"
+  exit 0
+fi
+
+exit 0

--- a/harness-engineering/hooks/hook-lib-config.sh
+++ b/harness-engineering/hooks/hook-lib-config.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# hook-lib-config.sh — Config-path detection functions
+#
+# Separation rationale: these three functions are CONFIG-domain concerns.
+# Everything else (FSM, state I/O, locking, tasks, handoff) lives in
+# hook-lib-core.sh. Keeping config-path detection here allows unit testing
+# and future replacement without touching the core state machine.
+#
+# Do NOT source hook-lib-core.sh here — hook-lib.sh (the stub) handles
+# the sourcing order: core first, then this file.
+#
+# Functions exported:
+#   is_config_path <path>          — returns 0 if path is a config file
+#   is_write_to_config <command>   — returns 0 if command writes to config
+#   _command_targets_config <cmd> <config_home>  — internal helper
+
+is_config_path() {
+  local path="$1"
+  local ch="$HOME/.claude"
+  # State files: block agent Edit/Write/Bash at PreToolUse boundary.
+  # hook-internal write_state() bypasses this entirely because hooks call
+  # write_state directly — no PreToolUse gate is traversed.
+  local sd="${STATE_DIR:-/tmp/claude-session}"
+  path="${path/#\~/$HOME}"
+  # macOS /tmp <-> /private/tmp symlink: normalize both sides for comparison
+  local path_alt="$path" sd_alt="$sd"
+  case "$path" in /tmp/*) path_alt="/private$path" ;; /private/tmp/*) path_alt="${path#/private}" ;; esac
+  case "$sd"   in /tmp/*) sd_alt="/private$sd" ;;   /private/tmp/*) sd_alt="${sd#/private}" ;;   esac
+  case "$path" in
+    "$sd"/*.json|"$sd"/*.lock|"$sd"/*.lock/*) return 0 ;;
+    "$sd_alt"/*.json|"$sd_alt"/*.lock|"$sd_alt"/*.lock/*) return 0 ;;
+  esac
+  case "$path_alt" in
+    "$sd"/*.json|"$sd"/*.lock|"$sd"/*.lock/*) return 0 ;;
+    "$sd_alt"/*.json|"$sd_alt"/*.lock|"$sd_alt"/*.lock/*) return 0 ;;
+  esac
+  case "$path" in
+    "$ch"/rules/*|"$ch"/agents/*|"$ch"/skills/*|"$ch"/hooks/*|"$ch"/plugins/*) return 0 ;;
+    "$ch"/benchmarks/evals/*|"$ch"/benchmarks/workflow-evals/*|"$ch"/benchmarks/tests/*) return 0 ;;
+    "$ch"/settings.json|"$ch"/CLAUDE.md) return 0 ;;
+  esac
+  echo "$path" | grep -qE '/\.claude/(settings|hooks|skills|agents|rules)' && return 0
+  return 1
+}
+
+is_write_to_config() {
+  local command="$1"
+  local ch="$HOME/.claude"
+
+  # --- Redirects: check if redirect TARGET is a config path ---
+  # Vector 5 (heredoc): cat << EOF > <config-path> is caught here because the
+  # sed pattern matches the single > redirect regardless of whether << heredoc
+  # syntax precedes it. No additional handling required.
+  local segment redirect_target
+  while IFS= read -r segment; do
+    redirect_target=$(echo "$segment" | sed -nE 's/.*[^>]>([^>].*)/\1/p' | sed 's/^[[:space:]]*//' | awk '{print $1}')
+    if [ -n "$redirect_target" ]; then
+      redirect_target="${redirect_target/#\~/$HOME}"
+      is_config_path "$redirect_target" && return 0
+    fi
+  done < <(echo "$command" | sed 's/&&/\n/g; s/;/\n/g')
+
+  # --- cd into config dir + any write ---
+  local cd_path
+  cd_path=$(echo "$command" | sed -nE 's/.*cd[[:space:]]+([^ &;|]+).*/\1/p')
+  if [ -n "$cd_path" ]; then
+    cd_path="${cd_path/#\~/$HOME}"
+    { echo "$cd_path" | grep -qF "$ch" || echo "$cd_path" | grep -qF '.claude'; } && return 0
+  fi
+
+  # --- Segment-aware write-verb check ---
+  _command_targets_config "$command" "$ch" && return 0
+
+  return 1
+}
+
+# Helper: segment-aware config path detection.
+# Splits the command on shell separators (;, &&, ||, |) and for each segment
+# checks only if the HEAD command is a write verb before scanning arguments.
+# This prevents false positives where a read-only verb (ls, cat) has a config
+# path as its argument — only write verbs can actually modify config files.
+#
+# Command-substitution flattening: $(...) and backtick substitutions are
+# promoted to sibling segments so that hidden write verbs like
+# `echo $(rm ~/.claude/hooks/x.sh)` are caught. A single flatten pass covers
+# the common case; deeply nested $(...) are extremely rare in practice.
+_command_targets_config() {
+  local command="$1" ch="$2"
+
+  # Flatten $(...) and backtick substitutions into sibling segments so that
+  # write verbs hidden inside command substitutions are not missed.
+  local command_flat
+  command_flat=$(echo "$command" | sed -E 's/\$\(/; /g; s/\)/; /g; s/`/; /g')
+
+  # Split on ; && || | into segments
+  local seg
+  while IFS= read -r seg; do
+    # Strip leading/trailing whitespace
+    seg="${seg#"${seg%%[! ]*}"}"
+    seg="${seg%"${seg##*[! ]}"}"
+    [ -z "$seg" ] && continue
+
+    # Strip leading variable assignments like FOO=bar VAR=baz cmd ...
+    local head="$seg"
+    while echo "$head" | grep -qE '^[A-Z_][A-Za-z0-9_]*='; do
+      head="${head#*=}"
+      # Remove the value token (up to next space)
+      head="${head#[^ ]* }"
+      head="${head#"${head%%[! ]*}"}"
+    done
+
+    # Extract the head command (first word)
+    local verb
+    verb="${head%% *}"
+    verb="${verb##*/}"  # strip any path prefix
+
+    # Determine if this segment's verb is a write verb.
+    # Case arms are grouped by category:
+    #   1. Unconditional write verbs (always write when invoked)
+    #   2. Conditional write verbs — file/network tools (write only under specific flags)
+    #   3. Git subcommands (write depends on subcommand + flags)
+    #   4. Shell dispatch wrappers (recurse into inner command)
+    #   5. Archive/patch extraction tools
+    local is_write=0
+    case "$verb" in
+
+      # ---- 1. Unconditional write verbs ----
+      cp|mv|touch|tee|rm|chmod|install|mkdir|rsync)
+        is_write=1
+        ;;
+
+      # ---- 2. Conditional write verbs — file/network tools ----
+      sed|perl)
+        # Only write if in-place flag present
+        if echo "$seg" | grep -qE '(sed[[:space:]]+-i|sed[[:space:]]+--in-place|perl[[:space:]]+-[a-zA-Z]*[pi])'; then
+          is_write=1
+        fi
+        # perl -e with file-write patterns targeting config
+        if [ "$is_write" -eq 0 ] && echo "$seg" | grep -qE 'perl[[:space:]]+-[eE]' && \
+           echo "$seg" | grep -qE '(open\s*\(.*[">]|File::Copy|copy\s*\(|move\s*\()' && \
+           echo "$seg" | grep -qF "$ch"; then
+          is_write=1
+        fi
+        ;;
+      python|python3)
+        # Only write if -c with open(...'w'...)
+        if echo "$seg" | grep -qE 'python3?[[:space:]]+-c.*open.*w'; then
+          is_write=1
+        fi
+        ;;
+      ln)
+        # Vector 2: symlink creation — ln / ln -s / ln -sf <src> <target>.
+        # The target (last arg) determines where the write lands.
+        local ln_last
+        ln_last=$(echo "$seg" | awk '{print $NF}')
+        ln_last="${ln_last/#\~/$HOME}"
+        if is_config_path "$ln_last"; then
+          is_write=1
+        fi
+        ;;
+      node)
+        # Vector 3a: node -e "...writeFile/fs.write..." targeting a config path.
+        # Only flag when the -e string contains a write indicator AND a config path.
+        if echo "$seg" | grep -qE 'node[[:space:]]+-e' && \
+           echo "$seg" | grep -qE '(writeFile|fs\.write|createWriteStream)' && \
+           echo "$seg" | grep -qF "$ch"; then
+          is_write=1
+        fi
+        ;;
+      ruby)
+        # Vector 3b: ruby -e "...File.write/File.open.*w..." targeting a config path.
+        if echo "$seg" | grep -qE 'ruby[[:space:]]+-e' && \
+           echo "$seg" | grep -qE '(File\.write|File\.open.*['"'"'"]w['"'"'"])' && \
+           echo "$seg" | grep -qF "$ch"; then
+          is_write=1
+        fi
+        ;;
+      dd)
+        # Vector 4: dd of=<config-path>.
+        if echo "$seg" | grep -qE 'of='; then
+          local dd_of
+          dd_of=$(echo "$seg" | grep -oE 'of=[^ ]+' | sed 's/^of=//')
+          dd_of="${dd_of/#\~/$HOME}"
+          if is_config_path "$dd_of"; then
+            is_write=1
+          fi
+        fi
+        ;;
+      awk|gawk|mawk)
+        # awk -i inplace modifies files in-place (like sed -i)
+        if echo "$seg" | grep -qE '(awk|gawk|mawk)[[:space:]].*-i[[:space:]]*inplace'; then
+          is_write=1
+        fi
+        ;;
+      curl)
+        # Vector 7: curl -o / --output <config-path>.
+        # Detects file download targeting a config path via the output flag.
+        local curl_out
+        curl_out=$(echo "$seg" | grep -oE '(-o[[:space:]]*|--output[= ])[^ ]+' | awk '{print $NF}')
+        if [ -n "$curl_out" ]; then
+          curl_out="${curl_out/#\~/$HOME}"
+          if is_config_path "$curl_out"; then
+            is_write=1
+          fi
+        fi
+        ;;
+      wget)
+        # Vector 8: wget -O / --output-document <config-path>.
+        local wget_out
+        wget_out=$(echo "$seg" | grep -oE '(-O[[:space:]]*|--output-document[= ])[^ ]+' | awk '{print $NF}')
+        if [ -n "$wget_out" ]; then
+          wget_out="${wget_out/#\~/$HOME}"
+          if is_config_path "$wget_out"; then
+            is_write=1
+          fi
+        fi
+        ;;
+
+      # ---- 3. Git subcommands ----
+      git)
+        # Vector 1: git checkout/restore/apply targeting config paths.
+        # git checkout main or git restore . are NOT flagged (no config path in args).
+        # git checkout HEAD -- ~/.claude/hooks/x.sh IS flagged.
+        # Fix #3: also check for literal '.claude/' because $ch contains the
+        # expanded path ($HOME/.claude) and won't match a tilde-prefixed arg
+        # like ~/.claude/hooks/x.sh that the shell hasn't yet expanded.
+        # Vector 14: git reset --hard — unconditionally overwrites the working tree.
+        # Vector 15: git clean -f / -fd — deletes untracked files; requires -f flag.
+        local git_sub
+        git_sub=$(echo "$seg" | awk '{print $2}')
+        case "$git_sub" in
+          checkout|restore|apply)
+            if echo "$seg" | grep -qF "$ch" || echo "$seg" | grep -qF '.claude/'; then
+              is_write=1
+            fi
+            ;;
+          reset)
+            # Only --hard rewrites tracked files; --soft and --mixed do not touch working tree.
+            # Return immediately — reset --hard affects all tracked files in CWD, so no
+            # config-path argument is required; the verb alone is sufficient to block.
+            if echo "$seg" | grep -qE '(^|[[:space:]])--hard([[:space:]]|$)'; then
+              return 0
+            fi
+            ;;
+          clean)
+            # Requires -f (force) flag to actually delete; -fd removes directories too.
+            # Only flag when a config path is targeted explicitly or the CWD is inside config.
+            if echo "$seg" | grep -qE '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)'; then
+              if echo "$seg" | grep -qF "$ch" || echo "$seg" | grep -qF '.claude/'; then
+                is_write=1
+              fi
+            fi
+            ;;
+        esac
+        ;;
+
+      # ---- 4. Shell dispatch wrappers (recurse into inner command) ----
+      sh|bash|zsh)
+        # Vector 6: sh -c / bash -c / zsh -c — extract the -c argument and
+        # recursively check it. Recursion is limited to 2 levels via
+        # _IWTC_DEPTH to cover double-nested invocations like
+        # sh -c 'bash -c "..."' without unbounded recursion.
+        # Note: env -u _IWTC_DEPTH could reset the counter and bypass the limit,
+        # but Claude generates these commands (not external attackers), so this
+        # is an acceptable risk — document rather than over-engineer.
+        if echo "$seg" | grep -qE '[[:space:]]+-c[[:space:]]'; then
+          local inner_cmd depth
+          depth="${_IWTC_DEPTH:-0}"
+          if [ "$depth" -lt 2 ]; then
+            # Extract everything after -c (strip optional surrounding quotes)
+            inner_cmd=$(echo "$seg" | sed -nE "s/.*[[:space:]]-c[[:space:]]+['\"]?([^'\"]+)['\"]?.*/\1/p")
+            if [ -n "$inner_cmd" ]; then
+              _IWTC_DEPTH=$(( depth + 1 )) is_write_to_config "$inner_cmd" && is_write=1
+            fi
+          fi
+        fi
+        ;;
+      env)
+        # Vector 9: env [FLAGS] [KEY=VALUE...] <cmd> [args] — strip leading dash-flags
+        # and KEY=VALUE tokens to find the real command, then re-check recursively.
+        # Covers: env sh -c '...', env FOO=bar bash -c '...', env -S 'bash -c ...'
+        local env_rest depth
+        depth="${_IWTC_DEPTH:-0}"
+        if [ "$depth" -lt 2 ]; then
+          env_rest="$seg"
+          # Strip the leading 'env' word
+          env_rest="${env_rest#env}"
+          env_rest="${env_rest#"${env_rest%%[! ]*}"}"
+          # Strip leading flags (e.g. -i, -u VAR, -S 'cmd') and KEY=VALUE tokens
+          while true; do
+            local token
+            token="${env_rest%% *}"
+            case "$token" in
+              -*) env_rest="${env_rest#* }"; env_rest="${env_rest#"${env_rest%%[! ]*}"}" ;;
+              *=*) env_rest="${env_rest#* }"; env_rest="${env_rest#"${env_rest%%[! ]*}"}" ;;
+              *) break ;;
+            esac
+          done
+          # env_rest now starts with the real command; recurse if non-empty
+          if [ -n "$env_rest" ]; then
+            _IWTC_DEPTH=$(( depth + 1 )) is_write_to_config "$env_rest" && is_write=1
+          fi
+        fi
+        ;;
+      xargs)
+        # Vector 10: xargs ... sh -c 'cmd' — detect shell dispatch inside xargs args.
+        # We only care if the xargs command itself is dispatching a shell with -c,
+        # not the items piped to xargs. If shell dispatch is found, extract the
+        # -c argument and recurse.
+        local depth
+        depth="${_IWTC_DEPTH:-0}"
+        if [ "$depth" -lt 2 ]; then
+          if echo "$seg" | grep -qE '(sh|bash|zsh)[[:space:]]+-c[[:space:]]'; then
+            local inner_cmd
+            inner_cmd=$(echo "$seg" | sed -nE "s/.*(sh|bash|zsh)[[:space:]]+-c[[:space:]]+['\"]?([^'\"]+)['\"]?.*/\2/p")
+            if [ -n "$inner_cmd" ]; then
+              _IWTC_DEPTH=$(( depth + 1 )) is_write_to_config "$inner_cmd" && is_write=1
+            fi
+          fi
+        fi
+        ;;
+
+      # ---- 5. Archive/patch extraction tools ----
+      tar)
+        # Vector 11: tar -xf / tar xf — extraction that writes to a config path.
+        # Flags to detect: -x or x mode (extract), plus either -C config_path or
+        # a config path appearing as an extraction destination argument.
+        if echo "$seg" | grep -qE 'tar[[:space:]]+[^ ]*x'; then
+          # Check for -C <config_path>
+          local tar_C
+          tar_C=$(echo "$seg" | grep -oE '(-C|--directory)[[:space:]]+[^ ]+' | awk '{print $NF}')
+          if [ -n "$tar_C" ]; then
+            tar_C="${tar_C/#\~/$HOME}"
+            if is_config_path "$tar_C"; then
+              is_write=1
+            fi
+          fi
+          # Also check if any arg directly references a config path
+          if [ "$is_write" -eq 0 ] && { echo "$seg" | grep -qF "$ch" || echo "$seg" | grep -qF '.claude/'; }; then
+            is_write=1
+          fi
+        fi
+        ;;
+      unzip)
+        # Vector 12: unzip -d <config_path> — extraction targeting a config directory.
+        local unzip_d
+        unzip_d=$(echo "$seg" | grep -oE '(-d|--directory)[[:space:]]+[^ ]+' | awk '{print $NF}')
+        if [ -n "$unzip_d" ]; then
+          unzip_d="${unzip_d/#\~/$HOME}"
+          if is_config_path "$unzip_d"; then
+            is_write=1
+          fi
+        fi
+        # Also catch unzip directly into a config path without -d flag
+        if [ "$is_write" -eq 0 ] && { echo "$seg" | grep -qF "$ch" || echo "$seg" | grep -qF '.claude/'; }; then
+          is_write=1
+        fi
+        ;;
+      patch)
+        # Vector 13: patch targeting a config path — patch <file> or patch -o <file>.
+        if echo "$seg" | grep -qF "$ch" || echo "$seg" | grep -qF '.claude/'; then
+          is_write=1
+        fi
+        ;;
+    esac
+
+    [ "$is_write" -eq 0 ] && continue
+
+    # Scan args of this segment for config paths
+    local word
+    for word in $seg; do
+      word="${word/#\~/$HOME}"
+      is_config_path "$word" && return 0
+    done
+
+    # Fallback: check if .claude appears as substring in segment (handles quoted python -c paths)
+    echo "$seg" | grep -qF "$ch" && return 0
+
+  done < <(echo "$command_flat" | sed 's/||/\n/g; s/&&/\n/g; s/|/\n/g; s/;/\n/g')
+
+  return 1
+}

--- a/harness-engineering/hooks/hooks.json
+++ b/harness-engineering/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/config-worktree-guard.sh",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/config-worktree-guard.sh",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/config-worktree-guard.sh",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/config-worktree-guard.sh",
             "timeout": 5
           }
         ]
@@ -26,12 +26,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/config-guardian-worktree-guard.sh",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/config-guardian-worktree-guard.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/config-agent-dispatch-guard.sh",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/config-agent-dispatch-guard.sh",
             "timeout": 5
           }
         ]
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/subagent-validate-config.sh",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/subagent-validate-config.sh",
             "timeout": 10
           }
         ]
@@ -53,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/subagent-validate-config.sh",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/subagent-validate-config.sh",
             "timeout": 10
           }
         ]
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/subagent-validate-config.sh",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/subagent-validate-config.sh",
             "timeout": 10
           }
         ]

--- a/harness-engineering/hooks/subagent-validate-config.sh
+++ b/harness-engineering/hooks/subagent-validate-config.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# SubagentStop hook: Validate config agent outputs and drive config phase transitions
+#
+# Handles: config-guardian, config-planner, config-editor
+# Extracted from subagent-validate.sh to isolate config-domain logic.
+# All phase changes are gated by validate_transition() to prevent ghost
+# SubagentStop events from corrupting state after workflow interruption.
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT=$(cat)
+export HOOK_INPUT="$INPUT"
+# Source host core (state machine) + plugin config (path detection)
+source "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/hook-lib-core.sh"
+source "${CLAUDE_PLUGIN_ROOT}/hooks/hook-lib-config.sh"
+
+if is_bypass_mode; then exit 0; fi
+
+STOP_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+[ "$STOP_ACTIVE" = "true" ] && exit 0
+
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // ""')
+LAST_MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // ""')
+
+STATE=$(read_state)
+PHASE=$(get_phase "$STATE")
+
+# --- Reusable validation: tasks.json structure ---
+# Usage: _validate_tasks_json <json_string>
+# Emits error and exits 2 if invalid; writes tasks.json handoff on success.
+_validate_tasks_json() {
+  local tasks_json="$1"
+  local errors=()
+  local task_count
+  task_count=$(echo "$tasks_json" | jq '.tasks | length')
+  if [ "$task_count" -lt 1 ]; then
+    errors+=("tasks array is empty")
+  fi
+  if ! echo "$tasks_json" | jq -e '.execution_order' >/dev/null 2>&1; then
+    errors+=("missing execution_order")
+  fi
+  if ! echo "$tasks_json" | jq -e '.target_branch' >/dev/null 2>&1; then
+    errors+=("missing target_branch")
+  fi
+  local missing_fields
+  missing_fields=$(echo "$tasks_json" | jq -r '
+    .tasks[] | .id as $id |
+    (
+      (if (.id | type) != "string" or (.id | length) == 0 then "id" else empty end),
+      (if (.title | type) != "string" or (.title | length) == 0 then "title" else empty end),
+      (if (.scope | type) != "array" then "scope" else empty end),
+      (if (.acceptance_criteria | type) != "array" or (.acceptance_criteria | length) == 0 then "acceptance_criteria" else empty end),
+      (if .depends_on == null or (.depends_on | type) != "array" then "depends_on" else empty end),
+      (if .action == null or (.action | type) != "string" then "action" else empty end)
+    ) | "Task \($id): missing \(.)"
+  ' 2>/dev/null)
+  if [ -n "$missing_fields" ]; then
+    while IFS= read -r line; do
+      errors+=("$line")
+    done <<< "$missing_fields"
+  fi
+  if [ "${#errors[@]}" -gt 0 ]; then
+    local err_msg
+    err_msg=$(printf '%s; ' "${errors[@]}")
+    emit_block "tasks.json validation failed: ${err_msg%. }. Fix tasks.json and re-run."
+    exit 2
+  fi
+  write_handoff "tasks.json" "$tasks_json"
+}
+
+# --- Reusable validation: plan.md required headers ---
+# Usage: _validate_plan_headers <content> <header1> [<header2> ...]
+# Emits error and exits 2 if any header is missing.
+_validate_plan_headers() {
+  local content="$1"
+  shift
+  local missing=()
+  local hdr
+  for hdr in "$@"; do
+    # Match ## or ### followed by the header text
+    local pattern
+    pattern="^#{2,3} ${hdr#\#\# }"
+    echo "$content" | grep -qE "$pattern" || missing+=("$hdr")
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    local missing_list
+    missing_list=$(printf '%s, ' "${missing[@]}")
+    emit_block "Missing required headers in plan: ${missing_list%, }. Add the missing sections and re-run."
+    exit 2
+  fi
+}
+
+case "$AGENT_TYPE" in
+  config-guardian)
+    transition_phase "$PHASE" "idle"
+    exit 0
+    ;;
+
+  config-planner)
+    # Config planner produces a CRUD plan
+    if echo "$LAST_MSG" | grep -qiE '(crud plan|create|update|delete|config.*plan)'; then
+      write_handoff "config-plan.md" "$LAST_MSG"
+      # Validate required headers in config-plan.md
+      _validate_plan_headers "$LAST_MSG" "## Goal" "## Current State" "## CRUD Plan"
+      # Extract tasks.json if present — validate structure
+      TASKS_JSON=$(echo "$LAST_MSG" | sed -n '/```json/,/```/p' | sed '1d;$d')
+      if [ -n "$TASKS_JSON" ] && echo "$TASKS_JSON" | jq -e '.tasks' >/dev/null 2>&1; then
+        _validate_tasks_json "$TASKS_JSON"
+        TASKS_FOUND=true
+      else
+        TASKS_FOUND=false
+      fi
+      # Initialize task tracking from tasks.json (synthetic T0 if absent)
+      TASKS_FILE="$(handoff_dir)/tasks.json"
+      init_tasks "$TASKS_FILE"
+      if validate_transition "$PHASE" "config_plan_review"; then
+        mutate_state '.workflow.phase = "config_plan_review" | .workflow.last_agent = "config-planner"' \
+          || log_mutation_failure "subagent-validate-config.sh:config_planner_review" "${MUTATE_STATE_LAST_REASON:-unknown}"
+      fi
+      if [ "$TASKS_FOUND" = true ]; then
+        emit_guidance "[CONFIG PLAN COMPLETE] Plan written to $(handoff_dir)/config-plan.md (tasks.json extracted). Present the config plan to the user for approval."
+      else
+        emit_guidance "[CONFIG PLAN COMPLETE] Plan written to $(handoff_dir)/config-plan.md (no tasks.json). Present the config plan to the user for approval."
+      fi
+      exit 0
+    fi
+    emit_block "Config plan not found in config-planner output. Expected a CRUD plan with Create/Update/Delete sections."
+    exit 2
+    ;;
+
+  config-editor)
+    # Config editor applies the plan — transition to verification
+    if validate_transition "$PHASE" "config_verifying"; then
+      mutate_state '.workflow.phase = "config_verifying" | .workflow.last_agent = "config-editor"' \
+        || log_mutation_failure "subagent-validate-config.sh:config_editor_verifying" "${MUTATE_STATE_LAST_REASON:-unknown}"
+    fi
+    emit_guidance "[CONFIG EDIT COMPLETE] Changes applied. Delegate to config-guardian for benchmarking."
+    exit 0
+    ;;
+
+  *)
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
5 config hook scripts migrated from claude-setup host (PR pmmm114/claude-setup#236 deleted them). hooks.json paths updated to CLAUDE_PLUGIN_ROOT. Scripts source host core + plugin config-lib.

Files added:
- hooks/config-worktree-guard.sh (98 lines)
- hooks/config-agent-dispatch-guard.sh (44 lines)
- hooks/config-guardian-worktree-guard.sh (57 lines)
- hooks/subagent-validate-config.sh (141 lines)
- hooks/hook-lib-config.sh (382 lines)

Ref: pmmm114/claude-setup#236