### PR TITLE
feat(error-reporter): structure issue output to observation-log taxonomy

### DIFF
--- a/error-reporter/.claude-plugin/plugin.json
+++ b/error-reporter/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "error-reporter",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Reads hook debug logs and creates GitHub issues when fail events occur"
 }

--- a/error-reporter/README.md
+++ b/error-reporter/README.md
@@ -46,35 +46,60 @@ Layer 1의 로그를 읽고, fail 이벤트 감지 시 GitHub Issue를 생성합
 
 ## GitHub Issue Format
 
+[observation-log 택소노미](https://github.com/pmmm114/claude-harness-engineering/issues/37)를 따릅니다.
+
+**대상 레포**: `pmmm114/claude-harness-engineering`
+
 Title 형식:
 
 ```
-[harness-debug] EVENT(agent_id) (session_id_8)
+[incident] EVENT(agent_id) (session_id_8)
 ```
 
 예시:
 
 ```
-[harness-debug] SubagentStop(tdd-implementer) (a1b2c3d4)
+[incident] SubagentStop(tdd-implementer) (a1b2c3d4)
 ```
 
-Issue body 구조 (raw data — 파싱/해석 없음):
+### Labels
 
-- **Raw State**: `state.json` 원본 전체 (JSON)
-- **Debug Log (last 50)**: debug log 마지막 50줄
-- **Transcript (last 20 lines)**: transcript 마지막 20줄
-- **Hook Input**: hook event input JSON 원본
+| Label | 설명 |
+|-------|------|
+| `type:incident` | 자동 생성은 항상 incident |
+| `auto:hook-failure` | 자동 생성 구분용 |
+| `severity:<level>` | 심각도 자동 분류 (아래 참조) |
+| `domain:<area>` | hook/agent/infra 중 자동 추론 |
+| `agent:<name>` | 관련 에이전트 (있을 때만) |
+
+### Severity 자동 분류
+
+| Event | 조건 | Severity |
+|-------|------|----------|
+| `StopFailure` | timeout 에러 | `A3-resource` |
+| `StopFailure` | 그 외 | `A1-coordination` |
+| `Stop` | block/deny 감지 | `A2-guard-recovered` |
+| `SubagentStop` | block/deny 감지 | `A2-guard-recovered` |
+
+### Body 구조
+
+observation-log 템플릿 필드를 따르되, 자동/수동을 구분합니다:
+
+| 필드 | 자동 채움 | 수작업 |
+|------|-----------|--------|
+| Event, Agent, Session ID, Phase, Trigger Commit | ✓ | |
+| Severity, Reproducibility ("observed once") | ✓ | |
+| Evidence (debug log, transcript, state, hook input) | ✓ | |
+| Counterfactual | | ✓ (placeholder) |
+| Hypothesis | | ✓ (placeholder) |
 
 ## Prerequisites
 
 - `jq` 설치 (hook input JSON 파싱에 필수)
 - `gh` CLI 설치 및 인증 (`gh auth login`)
-- 현재 디렉토리가 GitHub 리포지토리
-- `harness-debug` 라벨이 리포지토리에 존재
+- `pmmm114/claude-harness-engineering` 레포에 쓰기 권한
 
-```bash
-gh label create harness-debug --description "Auto-generated harness debug reports" --color "d93f0b" --force
-```
+라벨은 존재하지 않으면 자동 생성됩니다.
 
 ## Enable / Disable
 

--- a/error-reporter/scripts/report.sh
+++ b/error-reporter/scripts/report.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# error-reporter: Capture error stack and create GitHub issues asynchronously.
+# error-reporter: Capture error stack and create structured GitHub issues.
 # Pattern: synchronous snapshot (file reads) → fork (network I/O) → immediate exit 0.
+# Output format follows the observation-log taxonomy (pmmm114/claude-harness-engineering#37).
 # This script NEVER blocks the Claude Code hook chain.
 set +e
 
@@ -27,7 +28,6 @@ HAS_LOG=false
 # --- Threshold checks per event ---
 case "$EVENT" in
   StopFailure)
-    # Filter transient errors — not harness bugs, just provider-side noise
     SF_ERROR=$(echo "$INPUT" | jq -r '.error // ""')
     case "$SF_ERROR" in rate_limit|server_error) exit 0 ;; esac
     ;;
@@ -52,50 +52,130 @@ esac
 
 # === Phase 1: Synchronous snapshot (fast, file reads only) ===
 STATE_SNAPSHOT=$(cat "$STATE_FILE" 2>/dev/null || echo '{}')
+PHASE=$(echo "$STATE_SNAPSHOT" | jq -r '.phase // "unknown"')
+TRIGGER_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DEBUG_LOG_TAIL=$(tail -50 "$LOG_FILE" 2>/dev/null)
 TRANSCRIPT_TAIL=""
 [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] && TRANSCRIPT_TAIL=$(tail -20 "$TRANSCRIPT" 2>/dev/null)
+
+# --- Severity classification ---
+# StopFailure → A1 (coordination failure — session ended abnormally)
+# Stop with block/deny → A2 (guard recovered — hooks caught the problem)
+# SubagentStop with block/deny → A2 (guard recovered)
+# Timeout errors → A3 (resource exceeded)
+SEVERITY="A2-guard-recovered"
+case "$EVENT" in
+  StopFailure)
+    if echo "$SF_ERROR" | grep -qi 'timeout'; then
+      SEVERITY="A3-resource"
+    else
+      SEVERITY="A1-coordination"
+    fi
+    ;;
+esac
+
+# --- Domain inference from debug log hook names ---
+# Maps hook script names to their domain
+infer_domain() {
+  local hooks=""
+  if [ "$HAS_LOG" = true ]; then
+    hooks=$(jq -r '.hook // empty' "$LOG_FILE" 2>/dev/null | sort -u)
+  fi
+  # Also check agent_id for agent-domain mapping
+  case "$AGENT_ID" in
+    planner|tdd-implementer)       echo "domain:agent"; return ;;
+    config-planner|config-editor)  echo "domain:agent"; return ;;
+    config-guardian)               echo "domain:agent"; return ;;
+  esac
+  # Map hook names to domains
+  for h in $hooks; do
+    case "$h" in
+      *config-worktree*|*config-agent*|*config-guardian*) echo "domain:hook"; return ;;
+      *pre-edit*|*verify-before*|*pr-template*|*pr-review*) echo "domain:hook"; return ;;
+      *delegation*|*subagent-validate*|*tdd-dispatch*) echo "domain:hook"; return ;;
+      *session-recovery*|*state-recovery*|*compact*|*preflight*) echo "domain:infra"; return ;;
+    esac
+  done
+  echo "domain:hook"
+}
+DOMAIN=$(infer_domain)
+
+# --- Agent field ---
+AGENT_FIELD=""
+case "$AGENT_ID" in
+  planner|tdd-implementer|config-planner|config-editor|config-guardian)
+    AGENT_FIELD="$AGENT_ID"
+    ;;
+esac
 
 # === Phase 2: Fork to background — all network I/O happens here ===
 (
   mkdir "/tmp/claude-report-${SESSION}.lock" 2>/dev/null || exit 0
   trap 'rmdir "/tmp/claude-report-${SESSION}.lock" 2>/dev/null' EXIT
 
-  TITLE="[harness-debug] $EVENT${AGENT_ID:+($AGENT_ID)} (${SESSION:0:8})"
+  TITLE="[incident] $EVENT${AGENT_ID:+($AGENT_ID)} (${SESSION:0:8})"
 
-  REPORT_BODY="## Raw State
-\`\`\`json
-${STATE_SNAPSHOT:-(unavailable)}
-\`\`\`
+  REPORT_BODY="## Observation
 
-## Debug Log (last 50)
+**Event**: \`$EVENT\`${AGENT_ID:+ | **Agent**: \`$AGENT_ID\`}
+**Session ID**: \`${SESSION:0:8}\`
+**Phase**: \`$PHASE\`
+**Trigger Commit**: \`$TRIGGER_COMMIT\`
+**Severity**: \`$SEVERITY\`
+**Reproducibility**: observed once
+
+${EVENT} event fired during phase \`$PHASE\`.${AGENT_FIELD:+ Agent \`$AGENT_FIELD\` was active.}
+
+## Counterfactual
+
+<!-- What SHOULD have happened — fill in manually to make this observation actionable -->
+
+## Evidence
+
+### Debug Log (last 50 lines)
 \`\`\`
 ${DEBUG_LOG_TAIL:-(unavailable)}
 \`\`\`
 
-## Transcript (last 20 lines)
+### Transcript (last 20 lines)
 \`\`\`
 ${TRANSCRIPT_TAIL:-(unavailable)}
 \`\`\`
 
-## Hook Input
+### State Snapshot
+\`\`\`json
+${STATE_SNAPSHOT:-(unavailable)}
+\`\`\`
+
+### Hook Input
 \`\`\`json
 $INPUT
-\`\`\`"
+\`\`\`
 
-  # Attempt GitHub issue creation
+## Hypothesis
+
+<!-- Suspected root cause — fill in manually -->"
+
+  REPORT_REPO="pmmm114/claude-harness-engineering"
+
+  # Ensure required labels exist, then create issue
   if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-    REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null)
-    if [ -n "$REPO" ]; then
-      gh issue create \
-        --repo "$REPO" \
-        --title "$TITLE" \
-        --label "harness-debug" \
-        --body "$REPORT_BODY" \
-        >/dev/null 2>&1 || true
-      touch "$MARKER"
-      exit 0
-    fi
+    # Create labels if missing (idempotent — gh exits 0 if label exists)
+    gh label create "type:incident" --description "Immediate response needed" --color "D73A4A" --repo "$REPORT_REPO" 2>/dev/null || true
+    gh label create "auto:hook-failure" --description "Auto-generated by error-reporter" --color "EDEDED" --repo "$REPORT_REPO" 2>/dev/null || true
+    gh label create "severity:$SEVERITY" --description "" --color "FFA500" --repo "$REPORT_REPO" 2>/dev/null || true
+
+    LABELS="type:incident,auto:hook-failure,severity:${SEVERITY},${DOMAIN}"
+    [ -n "$AGENT_FIELD" ] && LABELS="${LABELS},agent:${AGENT_FIELD}"
+
+    gh issue create \
+      --repo "$REPORT_REPO" \
+      --title "$TITLE" \
+      --label "$LABELS" \
+      --body "$REPORT_BODY" \
+      >/dev/null 2>&1 || true
+    touch "$MARKER"
+    exit 0
   fi
 
   # Fallback: save to local file


### PR DESCRIPTION
## Summary

error-reporter 플러그인이 생성하는 GitHub Issue를 harness-engineering의 observation-log 택소노미에 맞게 구조화한다. 비구조적 raw dump에서 Observation/Counterfactual/Evidence/Hypothesis 4섹션 구조로 전환하고, `type:incident`, `auto:hook-failure`, `severity:*`, `domain:*`, `agent:*` 라벨 택소노미를 적용한다.

## Changes

- **Label 체계 전환**: `harness-debug` 단일 라벨 → observation-log 택소노미 (`type:incident`, `auto:hook-failure`, `severity:<level>`, `domain:<area>`, `agent:<name>`)
- **Body 구조화**: Raw State/Debug Log/Transcript/Hook Input → Observation/Counterfactual(placeholder)/Evidence/Hypothesis(placeholder) 섹션
- **자동 필드 추출**: state file에서 `phase`, git에서 `trigger_commit`, event 기반 `severity` 자동 분류, hook name/agent_id 기반 `domain` 추론
- **대상 레포 고정**: CWD 기반 `gh repo view` → `pmmm114/claude-harness-engineering` 하드코딩
- **라벨 자동 생성**: 존재하지 않는 라벨은 `gh label create`로 idempotent 생성
- **Version bump**: 2.0.0 → 3.0.0

## Test Plan

- [ ] StopFailure 이벤트 시뮬레이션 → `type:incident` + `severity:A1-coordination` 라벨 확인
- [ ] SubagentStop with block/deny → `severity:A2-guard-recovered` + `agent:*` 라벨 확인
- [ ] body에 session_id, phase, trigger_commit 필드 존재 확인
- [ ] `gh issue list --repo pmmm114/claude-harness-engineering --label auto:hook-failure` 쿼리 작동 확인

Closes pmmm114/claude-harness-engineering#43

🤖 Generated with [Claude Code](https://claude.com/claude-code)