### PR TITLE
fix(dashboard): SC2188 in bridge_enrichment_test + expand shellcheck CI to repo-wide

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   shellcheck:
-    name: ShellCheck (error-reporter)
+    name: ShellCheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,9 +20,7 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         with:
           severity: warning
-          # Initial rollout scopes the gate to error-reporter only. dashboard
-          # has two pre-existing SC2188 warnings in its test scripts — folded
-          # into a follow-up PR. Expand `scandir` once those are resolved.
-          scandir: './error-reporter'
-          additional_files: |
-            error-reporter/scripts/report.sh
+          # Repo-wide scope. Initial rollout in PR #11 was scoped to
+          # error-reporter only because dashboard/tests/bridge_enrichment_test.sh
+          # had two pre-existing SC2188 warnings. Those are fixed in issue #13,
+          # so the gate now covers every *.sh in the repo.

--- a/dashboard/tests/bridge_enrichment_test.sh
+++ b/dashboard/tests/bridge_enrichment_test.sh
@@ -45,7 +45,7 @@ get_output() {
 }
 
 reset_output() {
-  > "/tmp/bridge-test-output-$$"
+  : > "/tmp/bridge-test-output-$$"
 }
 
 assert_eq() {
@@ -250,7 +250,7 @@ echo "Test 7: Empty stack file -> passthrough"
 start_listener
 reset_output
 
-> "$STACK_FILE"
+: > "$STACK_FILE"
 
 TOOL_EVENT=$(jq -n \
   --arg event "PreToolUse" \


### PR DESCRIPTION
## Summary

Fixes #13.

PR #11 landed a shellcheck CI workflow but **deliberately scoped** it to `error-reporter/` because `dashboard/tests/bridge_enrichment_test.sh` had two pre-existing SC2188 warnings that would fail the build:

```
dashboard/tests/bridge_enrichment_test.sh:48:3: warning: This redirection doesn't have a command. Move to its command (or use 'true' as no-op). [SC2188]
dashboard/tests/bridge_enrichment_test.sh:253:1: warning: This redirection doesn't have a command. Move to its command (or use 'true' as no-op). [SC2188]
```

Both sites intended "truncate or create the file" (test fixture reset). The canonical SC2188-compliant form is to prefix with the null command `:` (or `true`). `:` is preferred — it's the standard POSIX idiom for "do nothing" and is lighter than `true`.

## Changes

### `dashboard/tests/bridge_enrichment_test.sh`

| Line | Before | After |
|---|---|---|
| 48 | `> "/tmp/bridge-test-output-$$"` | `: > "/tmp/bridge-test-output-$$"` |
| 253 | `> "$STACK_FILE"` | `: > "$STACK_FILE"` |

Behavior unchanged — both sites still open-truncate the target file. This is the `reset_output()` helper and the Test 7 fixture setup respectively. `:` is a shell builtin that evaluates its arguments and returns 0, making the redirect have a well-defined command.

### `.github/workflows/shellcheck.yml`

- Dropped `scandir: ./error-reporter` and the `additional_files:` list. The action now uses its default scan behavior (repo-wide).
- Removed the `(error-reporter)` suffix from the job name — the scope is now repo-wide.
- Updated the inline comment to reference #13 as the resolved blocker.

## Verification

```
$ find . -name '*.sh' -not -path './.git/*' -print0 | xargs -0 shellcheck -S warning
$ echo $?
0
```

All 8 shell scripts in the repo pass `shellcheck -S warning` cleanly with shellcheck 0.11.0:

- `dashboard/scripts/bridge.sh`
- `dashboard/scripts/lib/enrichment.sh`
- `dashboard/scripts/lib/socket-relay.sh`
- `dashboard/scripts/lib/stack-tracker.sh`
- `dashboard/tests/bridge_enrichment_test.sh` ← fixed by this PR
- `dashboard/tests/bridge_test.sh`
- `dashboard/tests/stack-tracker_test.sh`
- `error-reporter/scripts/report.sh`

## Test plan

- [x] `bash -n dashboard/tests/bridge_enrichment_test.sh` — syntax passes
- [x] `shellcheck -S warning` repo-wide — clean
- [ ] GitHub Actions run of the expanded workflow on this PR — should pass on all 8 files

## Risk

Minimal. The `:` prefix is a canonical shell idiom; no runtime behavior change. The workflow scope expansion is additive (more coverage) not restrictive.

Fixes #13