### PR TITLE
refactor(error-reporter): drop hardcoded agent allowlist (Approach D) + fix hook-source bug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    paths:
+      - 'error-reporter/**'
+      - '.github/workflows/tests.yml'
+  pull_request:
+    paths:
+      - 'error-reporter/**'
+      - '.github/workflows/tests.yml'
+
+jobs:
+  error-reporter-smoke:
+    name: error-reporter end-to-end smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Run smoke test
+        run: bash error-reporter/tests/end_to_end_test.sh

--- a/error-reporter/README.md
+++ b/error-reporter/README.md
@@ -84,9 +84,11 @@ Title 형식:
 | `auto:hook-failure` | 자동 생성 구분용 |
 | `severity:<level>` | 심각도 자동 분류 (아래 참조) |
 | `reporter:domain:<area>` | hook/agent/infra 중 자동 추론 (플러그인 namespace) |
-| `reporter:agent:<name>` | 관련 에이전트 (있을 때만, 플러그인 namespace) |
+| `reporter:agent:<name>` | `agent_id` 가 있는 경우 — 값은 Claude Code 가 `Agent(subagent_type=...)` 에 전달한 문자열 그대로 (하네스-코어/플러그인 공급 agent 모두) |
 
 > `reporter:` 접두사는 다른 자동화/사람이 소유한 `domain:*`/`agent:*` 라벨과의 충돌을 방지하기 위한 namespace 입니다 (E4 리뷰 피드백).
+>
+> `reporter:agent:<name>` 의 `<name>` 은 **하드코딩된 allowlist 없이** hook input 의 `agent_id` 필드를 그대로 반영합니다 (issue #15). 하네스-코어 agent (`planner`, `editor`, `guardian`) 는 물론, 다른 플러그인이 공급하는 sub-agent (예: skill-creator 의 `grader`/`comparator`/`analyzer`, code-simplifier 의 `code-simplifier`) 도 자동으로 per-agent 라벨을 받습니다. 하네스의 `subagent-validate.sh` 가 이미 `agent_id` 값을 게이트하므로 플러그인 수준의 중복 검증은 불필요하다는 설계 판단입니다.
 
 ### Severity 자동 분류
 

--- a/error-reporter/scripts/report.sh
+++ b/error-reporter/scripts/report.sh
@@ -92,6 +92,11 @@ HAS_LOG=false
 [ -f "$LOG_FILE" ] && HAS_LOG=true
 
 # --- Threshold checks per event ---
+# TRIGGER_HOOK: populated for Stop/SubagentStop from the last entry that
+# survived EXPECTED_DENY_FILTER — i.e. the actual hook that tripped the
+# incident threshold. Used by infer_domain(). Empty for StopFailure
+# (the event isn't a hook deny, it's an upstream API error).
+TRIGGER_HOOK=""
 case "$EVENT" in
   StopFailure)
     SF_ERROR=$(echo "$INPUT" | jq -r '.error // ""')
@@ -126,8 +131,10 @@ case "$EVENT" in
     '
     if [ "$EVENT" = "SubagentStop" ] && [ -n "$AGENT_ID" ]; then
       BLOCK_COUNT=$(jq -r --arg aid "$AGENT_ID" "$EXPECTED_DENY_FILTER | select(.agent_id == \$aid or .agent_id == null) | .decision" "$LOG_FILE" 2>/dev/null | wc -l | tr -d ' ')
+      TRIGGER_HOOK=$(jq -r --arg aid "$AGENT_ID" "$EXPECTED_DENY_FILTER | select(.agent_id == \$aid or .agent_id == null) | .hook // empty" "$LOG_FILE" 2>/dev/null | tail -1)
     else
       BLOCK_COUNT=$(jq -r "$EXPECTED_DENY_FILTER | .decision" "$LOG_FILE" 2>/dev/null | wc -l | tr -d ' ')
+      TRIGGER_HOOK=$(jq -r "$EXPECTED_DENY_FILTER | .hook // empty" "$LOG_FILE" 2>/dev/null | tail -1)
     fi
     [ "${BLOCK_COUNT:-0}" -lt 1 ] && exit 0
     ;;
@@ -160,39 +167,40 @@ case "$EVENT" in
     ;;
 esac
 
-# --- Domain inference from debug log hook names ---
-# Maps hook script names to their domain
+# --- Domain inference (issue #15 refactor) ---
+#
+# Classify the incident into a reporter:domain:* bucket. Two signals:
+#
+# 1. $AGENT_ID truthy → reporter:domain:agent. **No allowlist.** The harness
+#    already gates which agent_id values reach a SubagentStop event via
+#    subagent-validate.sh + settings.json hook matchers, so any value that
+#    gets here is by definition a real agent invocation. Plugin-provided
+#    agents (skill-creator's grader/comparator/analyzer, code-simplifier,
+#    etc.) are handled automatically — no per-plugin update needed. This
+#    replaces the earlier hardcoded `planner|tdd-implementer|config-*`
+#    allowlist that had drifted from the real roster. See issue #15 and the
+#    5-engineer review panel findings (Approach D).
+#
+# 2. $TRIGGER_HOOK = the single hook that tripped the threshold, extracted
+#    from EXPECTED_DENY_FILTER | tail -1 (set in the case arm above). This
+#    replaces the earlier "sort -u over all hooks + first match wins" logic,
+#    which was alphabetically arbitrary and often misclassified incidents.
 infer_domain() {
-  local hooks=""
-  if [ "$HAS_LOG" = true ]; then
-    hooks=$(jq -r '.hook // empty' "$LOG_FILE" 2>/dev/null | sort -u)
-  fi
-  # Also check agent_id for agent-domain mapping
-  case "$AGENT_ID" in
-    planner|tdd-implementer)       echo "reporter:domain:agent"; return ;;
-    config-planner|config-editor)  echo "reporter:domain:agent"; return ;;
-    config-guardian)               echo "reporter:domain:agent"; return ;;
+  [ -n "$AGENT_ID" ] && { echo "reporter:domain:agent"; return; }
+  case "$TRIGGER_HOOK" in
+    *config-worktree*|*config-agent*|*config-guardian*) echo "reporter:domain:hook"; return ;;
+    *pre-edit*|*verify-before*|*pr-template*|*pr-review*) echo "reporter:domain:hook"; return ;;
+    *delegation*|*subagent-validate*|*tdd-dispatch*) echo "reporter:domain:hook"; return ;;
+    *session-recovery*|*state-recovery*|*compact*|*preflight*) echo "reporter:domain:infra"; return ;;
   esac
-  # Map hook names to domains
-  for h in $hooks; do
-    case "$h" in
-      *config-worktree*|*config-agent*|*config-guardian*) echo "reporter:domain:hook"; return ;;
-      *pre-edit*|*verify-before*|*pr-template*|*pr-review*) echo "reporter:domain:hook"; return ;;
-      *delegation*|*subagent-validate*|*tdd-dispatch*) echo "reporter:domain:hook"; return ;;
-      *session-recovery*|*state-recovery*|*compact*|*preflight*) echo "reporter:domain:infra"; return ;;
-    esac
-  done
   echo "reporter:domain:hook"
 }
 DOMAIN=$(infer_domain)
 
-# --- Agent field ---
-AGENT_FIELD=""
-case "$AGENT_ID" in
-  planner|tdd-implementer|config-planner|config-editor|config-guardian)
-    AGENT_FIELD="$AGENT_ID"
-    ;;
-esac
+# --- Agent field (issue #15 refactor) ---
+# Trust $AGENT_ID verbatim — see infer_domain() comment. The existing
+# ${AGENT_FIELD:+...} guards in the subshell handle the empty case naturally.
+AGENT_FIELD="$AGENT_ID"
 
 # === Phase 2: Fork to background — all network I/O happens here ===
 (

--- a/error-reporter/tests/end_to_end_test.sh
+++ b/error-reporter/tests/end_to_end_test.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# error-reporter end-to-end smoke test.
+#
+# Covers the full pipeline (threshold → phase 1 → fork → fallback write) with
+# synthetic hook input, a fake gh that always fails (so no real GitHub
+# interaction), and a temp CLAUDE_PLUGIN_DATA. Designed to run in CI with
+# zero external dependencies beyond jq and bash.
+#
+# Key invariants verified:
+# 1. `--self-test` runs cleanly and reports no side effects.
+# 2. Known harness agent_id ("editor") flows through the SubagentStop path
+#    and lands in the fallback report body.
+# 3. **Issue #15 Approach D**: plugin-provided / unknown agent_id ("grader")
+#    flows through identically — no allowlist, no special-casing. Regression
+#    fence for the drift class the refactor removed.
+
+set +e
+cd "$(dirname "$0")/../.." || exit 1
+SCRIPT="$(pwd)/error-reporter/scripts/report.sh"
+
+PASS=0
+FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# --- Helpers ---
+
+make_fake_gh() {
+  # $1 = bin dir. Creates a gh stub that reports "authenticated" for
+  # `gh auth status` but FAILS every mutating call (`issue create`,
+  # `label create`). This exercises the realistic failure mode: gh is
+  # installed and auth'd but a specific command fails — which is the
+  # path that triggers error-reporter.log entries. Never touches real
+  # GitHub.
+  mkdir -p "$1"
+  cat > "$1/gh" <<'GH'
+#!/bin/bash
+case "$1" in
+  auth)
+    # `gh auth status` — pretend authenticated so the script enters
+    # the primary-sink block and then hits our forced issue-create failure.
+    exit 0
+    ;;
+  issue|label|repo)
+    # issue create / label create / repo view — force failure with a
+    # recognizable stderr line so the log entry is easy to grep.
+    echo "smoke-test fake gh $*: forced failure" >&2
+    exit 1
+    ;;
+  *)
+    echo "smoke-test fake gh: unhandled subcommand $*" >&2
+    exit 1
+    ;;
+esac
+GH
+  chmod +x "$1/gh"
+}
+
+make_synthetic_debug_log() {
+  # $1 = session id, $2 = agent_id (may be empty). Creates a jsonl with one
+  # deny entry from verify-before-done.sh (survives EXPECTED_DENY_FILTER
+  # because neither the hook nor the phase match any routine-deny rule).
+  mkdir -p /tmp/claude-debug
+  printf '{"ts":"2026-04-14T00:00:00Z","event":"PreToolUse","hook":"verify-before-done.sh","decision":"deny","reason":"synthetic smoke test","phase":"verifying","session":"%s","agent_id":"%s"}\n' \
+    "$1" "$2" > "/tmp/claude-debug/$1.jsonl"
+}
+
+wait_for_background() {
+  # $1 = session id. Polls for the session marker file to appear — that's
+  # the LAST side effect of the backgrounded subshell (touched after the
+  # fallback .md write succeeds). Cannot use lockdir disappearance because
+  # there's a race: lockdir may not even exist yet when polling starts.
+  local marker="/tmp/claude-report-$1.reported"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [ -f "$marker" ] && return 0
+    sleep 1
+  done
+  return 1
+}
+
+cleanup_session() {
+  # $1 = session id, $2 = test data dir
+  rm -rf "$2" \
+    "/tmp/claude-report-$1.reported" \
+    "/tmp/claude-report-$1.lock" \
+    "/tmp/claude-debug/$1.jsonl"
+}
+
+run_synthetic_subagent_stop() {
+  # $1 = agent_id, $2 = out var for SID, $3 = out var for TEST_DATA,
+  # $4 = out var for FALLBACK_FILE path.
+  local agent="$1"
+  local sid
+  local td
+  sid="smoke-$$-$(date +%s)-${agent}"
+  td=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+
+  make_fake_gh "$td/bin"
+  make_synthetic_debug_log "$sid" "$agent"
+
+  local input
+  input=$(printf '{"hook_event_name":"SubagentStop","session_id":"%s","agent_id":"%s","transcript_path":""}' "$sid" "$agent")
+
+  CLAUDE_PLUGIN_DATA="$td" PATH="$td/bin:$PATH" \
+    bash -c "printf '%s' '$input' | bash '$SCRIPT'"
+
+  wait_for_background "$sid"
+
+  local fallback
+  fallback=$(ls "$td/reports/${sid}-"*".md" 2>/dev/null | head -1)
+
+  printf -v "$2" '%s' "$sid"
+  printf -v "$3" '%s' "$td"
+  printf -v "$4" '%s' "$fallback"
+}
+
+# --- Test 1: --self-test diagnostic mode ---
+printf 'Test 1: --self-test runs cleanly with zero side effects\n'
+OUT=$(bash "$SCRIPT" --self-test 2>&1)
+RC=$?
+[ "$RC" -eq 0 ] && pass "exit 0" || fail "exit $RC"
+printf '%s\n' "$OUT" | grep -q "error-reporter self-test" && pass "header present" || fail "header missing"
+printf '%s\n' "$OUT" | grep -q "no side effects" && pass "no-side-effects banner" || fail "no-side-effects missing"
+
+# --- Test 2: SubagentStop with known harness agent_id=editor ---
+printf '\nTest 2: SubagentStop + agent_id=editor (known harness agent)\n'
+SID=""; TEST_DATA=""; FALLBACK_FILE=""
+run_synthetic_subagent_stop "editor" SID TEST_DATA FALLBACK_FILE
+
+if [ -n "$FALLBACK_FILE" ] && [ -f "$FALLBACK_FILE" ]; then
+  pass "fallback .md written"
+  grep -q '\*\*Agent\*\*: `editor`' "$FALLBACK_FILE" && pass "body has Agent=editor" || fail "body missing Agent=editor"
+  grep -q 'SubagentStop' "$FALLBACK_FILE" && pass "body has SubagentStop event" || fail "body missing event name"
+else
+  fail "no fallback .md created"
+fi
+
+LOG_FILE="$TEST_DATA/logs/error-reporter.log"
+if [ -f "$LOG_FILE" ]; then
+  grep -q 'status=fail' "$LOG_FILE" && pass "error-reporter.log has status=fail (gh fake failed)" || fail "no status=fail in log"
+  grep -q "sid=$SID" "$LOG_FILE" && pass "log entry matches session" || fail "log entry missing sid"
+else
+  fail "error-reporter.log not created"
+fi
+
+[ -f "/tmp/claude-report-$SID.reported" ] && pass "session marker touched" || fail "no marker"
+
+cleanup_session "$SID" "$TEST_DATA"
+
+# --- Test 3: Approach D regression fence — plugin-provided agent_id=grader ---
+printf '\nTest 3: SubagentStop + agent_id=grader (plugin-provided, Approach D)\n'
+SID=""; TEST_DATA=""; FALLBACK_FILE=""
+run_synthetic_subagent_stop "grader" SID TEST_DATA FALLBACK_FILE
+
+if [ -n "$FALLBACK_FILE" ] && [ -f "$FALLBACK_FILE" ]; then
+  grep -q '\*\*Agent\*\*: `grader`' "$FALLBACK_FILE" \
+    && pass "plugin-provided agent_id flows through to body (Approach D)" \
+    || fail "plugin-provided agent_id=grader NOT in body — Approach D regression"
+else
+  fail "no fallback .md for grader test"
+fi
+
+cleanup_session "$SID" "$TEST_DATA"
+
+# --- Test 4: StopFailure (no debug log required) ---
+printf '\nTest 4: StopFailure with synthetic error (no debug log path)\n'
+SID="smoke-sf-$$-$(date +%s)"
+TEST_DATA=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+make_fake_gh "$TEST_DATA/bin"
+INPUT=$(printf '{"hook_event_name":"StopFailure","session_id":"%s","error":"synthetic_smoke_error"}' "$SID")
+
+CLAUDE_PLUGIN_DATA="$TEST_DATA" PATH="$TEST_DATA/bin:$PATH" \
+  bash -c "printf '%s' '$INPUT' | bash '$SCRIPT'"
+
+wait_for_background "$SID"
+
+FALLBACK_FILE=$(ls "$TEST_DATA/reports/${SID}-"*".md" 2>/dev/null | head -1)
+if [ -n "$FALLBACK_FILE" ] && [ -f "$FALLBACK_FILE" ]; then
+  pass "StopFailure fallback .md written"
+  grep -q 'A1-coordination' "$FALLBACK_FILE" && pass "severity=A1-coordination" || fail "severity missing"
+else
+  fail "no StopFailure fallback .md"
+fi
+
+cleanup_session "$SID" "$TEST_DATA"
+
+# --- Summary ---
+printf '\nSummary: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [ "$FAIL" -eq 0 ]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #15.

The agent-name drift in `error-reporter/scripts/report.sh` turned out to be a symptom of a deeper problem: **the plugin was maintaining an allowlist that duplicated an invariant the harness already enforces**. A 5-engineer opus review panel was convened to analyze the design space before patching the symptom. Convergent finding: the allowlist must go, not be corrected.

## Background — why the drift happened

Pre-fix, `report.sh` had two hardcoded case statements:

```bash
case "$AGENT_ID" in
  planner|tdd-implementer)       echo "reporter:domain:agent"; return ;;
  config-planner|config-editor)  echo "reporter:domain:agent"; return ;;
  config-guardian)               echo "reporter:domain:agent"; return ;;
esac

# ...and a nearly identical second case for AGENT_FIELD
```

E1's investigation confirmed:
- **3 dead branches** — `config-planner`, `config-editor`, `config-guardian` don't match any real `$AGENT_ID` (they were renamed to unprefixed names in a pre-#9 refactor and never propagated here)
- **2 missing agents** — `editor` and `guardian` are real, current harness agents that `report.sh` was silently misclassifying
- **`tdd-implementer` is a ghost** — referenced in `~/.claude-harness/CLAUDE.md` prose but has no `agents/tdd-implementer.md` file (this is harness-side drift, outside this repo's scope)
- **Plugin-provided agents exist** — `skill-creator` ships `grader`/`comparator`/`analyzer`, `code-simplifier` ships its own agent. These appear as `$AGENT_ID` but were never in any allowlist

The plugin had been silently losing `reporter:agent:*` labels on `editor`, `guardian`, and every plugin-provided sub-agent for an unknown duration. The bug was invisible because PR #11's investigation showed zero error-reporter-generated issues existed on the target repo — the plugin's triage value was near-zero throughout.

## The design conflict

The 5-engineer panel produced two incompatible recommendations:

- **E2**: Drop the allowlist entirely. Any non-empty `$AGENT_ID` is an agent by definition — the harness's `subagent-validate.sh` already gates which values reach a SubagentStop event, so the plugin's re-validation is redundant. One line: `[ -n "$AGENT_ID" ] && echo "reporter:domain:agent"`.
- **E4**: Keep the allowlist, add drift-detection infrastructure (bats test + runtime warning).

E2 wins because:

1. **The README explicitly commits to self-containment** ("이 플러그인은 `hook-lib.sh`에 대한 런타임 의존이 없습니다"). E4's runtime-warning approach re-introduces a filesystem dependency on the harness layout.
2. **The allowlist is structurally unwinnable** — even if we correctly enumerate every hardness-core agent, plugin-provided sub-agents (`grader`, `comparator`, `analyzer`, `code-simplifier`, etc.) appear in production and would need indefinite maintenance.
3. **E4's mechanisms obsolete themselves** — with no list, there is no drift class to detect. "Drift prevention" is a degraded form of "remove the drifting thing".

## Changes

### 1. Approach D — drop the agent allowlist

`error-reporter/scripts/report.sh`:

```bash
# infer_domain()
-  case "$AGENT_ID" in
-    planner|tdd-implementer)       echo "reporter:domain:agent"; return ;;
-    config-planner|config-editor)  echo "reporter:domain:agent"; return ;;
-    config-guardian)               echo "reporter:domain:agent"; return ;;
-  esac
+  [ -n "$AGENT_ID" ] && { echo "reporter:domain:agent"; return; }

# AGENT_FIELD
-  AGENT_FIELD=""
-  case "$AGENT_ID" in
-    planner|tdd-implementer|config-planner|config-editor|config-guardian)
-      AGENT_FIELD="$AGENT_ID"
-      ;;
-  esac
+  AGENT_FIELD="$AGENT_ID"
```

Existing `${AGENT_FIELD:+...}` guards in the subshell block handle the empty case naturally.

### 2. Fix `infer_domain()` hook-source bug (E3, scoped in because same function)

Old:
```bash
hooks=$(jq -r '.hook // empty' "$LOG_FILE" 2>/dev/null | sort -u)
for h in $hooks; do case "$h" in ...; esac; done
```

"First match" was **alphabetical first**, not chronologically triggered. In a session with multiple deny'd hooks the classification was arbitrary.

New: extract `$TRIGGER_HOOK` from `EXPECTED_DENY_FILTER | tail -1` in the Stop/SubagentStop threshold block (reusing the same filter that computes `$BLOCK_COUNT`). The hook that actually tripped the incident classifies the incident.

```bash
# In the threshold block:
TRIGGER_HOOK=$(jq -r "$EXPECTED_DENY_FILTER | .hook // empty" "$LOG_FILE" 2>/dev/null | tail -1)

# In infer_domain():
case "$TRIGGER_HOOK" in
  *pre-edit*|*verify-before*|*pr-template*|*pr-review*) echo "reporter:domain:hook"; return ;;
  ...
esac
```

`$TRIGGER_HOOK` is explicitly empty for `StopFailure` (that event is an upstream API error, not a hook deny).

### 3. End-to-end smoke test

New `error-reporter/tests/end_to_end_test.sh` — plain bash, no bats. 12 assertions across 4 scenarios:

| Test | Coverage |
|---|---|
| 1 | `--self-test` runs with zero side effects |
| 2 | SubagentStop + known harness agent (`editor`) → fallback body + status=fail log + marker |
| 3 | **Approach D regression fence**: SubagentStop + plugin-provided agent (`grader`) → same path, no allowlist bypass |
| 4 | StopFailure + synthetic error → severity classification + fallback |

Uses a fake `gh` stub that authenticates OK but fails `issue create`/`label create` — exercises the realistic failure mode (auth'd gh + command failure) that triggers the diagnostic log path.

```
$ bash error-reporter/tests/end_to_end_test.sh
...
Summary: 12 passed, 0 failed
```

### 4. New CI workflow

`.github/workflows/tests.yml` runs the smoke test on `error-reporter/**` changes. Paired with the existing `shellcheck.yml` from PR #11 (which now covers repo-wide after #13).

### 5. README

`reporter:agent:<name>` row updated to document that the value is any `$AGENT_ID` Claude Code's `Agent(subagent_type=...)` caller provided — harness-core OR plugin-provided — with no allowlist enforcement.

## Out of scope (scoped intentionally)

- **Multi-label redesign of `infer_domain()`** (E3's bigger argument) — substring matching on hook names is still heuristic. E3 proposed replacing the `{hook,agent,infra}` taxonomy with orthogonal labels (`reporter:hook:<name>`, `reporter:phase:<phase>`, `reporter:event:<event>`). That's a label schema change needing its own design discussion and will be filed as a follow-up issue. E5's zero-blast-radius observation applies equally to that change whenever it happens.
- **`tdd-implementer` harness ghost reference** — `~/.claude-harness/CLAUDE.md` mentions `tdd-implementer` as an agent but `~/.claude-harness/agents/tdd-implementer.md` does not exist. This is harness-side drift, outside kb-cc-plugin. Will be noted in the #15 resolution comment for the harness maintainer's attention.
- **Drift-prevention infrastructure** — with no list, there's nothing to drift. The smoke test (regression fence for Approach D) is the only test added.

## Verification

- [x] `bash -n` syntax clean on `report.sh` and smoke test
- [x] `shellcheck -S warning` clean on both files
- [x] Smoke test `12 passed / 0 failed` locally
- [ ] GitHub Actions (shellcheck + tests) on this PR
- [ ] Post-merge: trigger a real deny event, verify `reporter:agent:<X>` label attaches for at least one `editor`/`guardian` incident

## Blast radius

Zero. PR #11's E5 confirmed live `gh issue list` returns `[]` for every `reporter:agent:*` label on the target repo. No existing issues to migrate, no saved queries to update, no dashboards to retune. Cut-over clean.

Fixes #15