### PR TITLE
feat(error-reporter): self-recursion guard when cwd resolves to report repo

### DIFF
--- a/error-reporter/scripts/report.sh
+++ b/error-reporter/scripts/report.sh
@@ -580,6 +580,17 @@ if [ -n "$PRESET_REQUEST" ]; then
 fi
 _resolve_repo
 
+# P0-6: Self-recursion guard — if REPORT_REPO resolves to the repo this plugin
+# ships from, emit a breadcrumb and exit without creating a GitHub Issue.
+# Prevents infinite incident loops when operators edit error-reporter source
+# (either Desktop/project/kb-cc-plugin or a /tmp/kb-cc-issue-* worktree).
+# Override for forks via ERROR_REPORTER_SELF_REPO env. See kb-cc-plugin#28.
+SELF_REPO="${ERROR_REPORTER_SELF_REPO:-pmmm114/kb-cc-plugin}"
+if [ -n "$REPORT_REPO" ] && [ "$REPORT_REPO" = "$SELF_REPO" ]; then
+  log_line "[$TS] status=self_suppress event=$EVENT sid=$SESSION cwd_repo=$REPORT_REPO"
+  exit 0
+fi
+
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // ""')
 AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // ""')
 

--- a/error-reporter/tests/end_to_end_test.sh
+++ b/error-reporter/tests/end_to_end_test.sh
@@ -443,6 +443,75 @@ RC=$?
 printf '%s\n' "$OUT" | grep -qF '[FAIL] preset: cannot check (CLAUDE_PLUGIN_ROOT unset)' && pass "T12e FAIL line" || fail "T12e FAIL line"
 rm -rf "$TD"
 
+# --- Test 13: Self-recursion guard (kb-cc-plugin#28) ---
+# When REPORT_REPO resolves to SELF_REPO (pmmm114/kb-cc-plugin), the reporter
+# must emit a breadcrumb and exit without ever invoking gh. Prevents infinite
+# incident loops when operators edit error-reporter source.
+printf '\nTest 13: self-suppress when REPORT_REPO matches SELF_REPO\n'
+TD=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+SID="smoke-t13-$$-$(date +%s)"
+mkdir -p "$TD/markers" "$TD/bin"
+touch "$TD/markers/.v3.1-opt-in-notice.ack"
+make_fake_gh_fatal "$TD/bin"
+INPUT=$(printf '{"hook_event_name":"StopFailure","session_id":"%s","error":"other","cwd":""}' "$SID")
+
+PATH="$TD/bin:$PATH" CLAUDE_PLUGIN_DATA="$TD" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+  ERROR_REPORTER_REPO=pmmm114/kb-cc-plugin \
+  bash -c "printf '%s' '$INPUT' | bash '$SCRIPT'"
+RC=$?
+[ "$RC" -eq 0 ] && pass "T13 exit 0" || fail "T13 exit $RC"
+sleep 1
+LOG_FILE="$TD/logs/error-reporter.log"
+[ -f "$LOG_FILE" ] && grep -q 'status=self_suppress' "$LOG_FILE" \
+  && pass "T13 log has status=self_suppress" \
+  || fail "T13 missing self_suppress log"
+[ ! -f "$TD/gh-was-called" ] && pass "T13 gh NOT invoked (self-suppress worked)" \
+  || fail "T13 gh was called — self-suppress failed"
+rm -rf "$TD"
+
+# --- Test 13b: non-self repo does NOT self-suppress ---
+printf '\nTest 13b: non-self repo proceeds past self-suppress guard\n'
+TD=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+SID="smoke-t13b-$$-$(date +%s)"
+mkdir -p "$TD/markers" "$TD/bin"
+touch "$TD/markers/.v3.1-opt-in-notice.ack"
+make_fake_gh_fatal "$TD/bin"
+INPUT=$(printf '{"hook_event_name":"StopFailure","session_id":"%s","error":"other","cwd":""}' "$SID")
+
+PATH="$TD/bin:$PATH" CLAUDE_PLUGIN_DATA="$TD" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+  ERROR_REPORTER_REPO=some/other-repo \
+  bash -c "printf '%s' '$INPUT' | bash '$SCRIPT'"
+RC=$?
+[ "$RC" -eq 0 ] && pass "T13b exit 0" || fail "T13b exit $RC"
+sleep 1
+LOG_FILE="$TD/logs/error-reporter.log"
+if [ -f "$LOG_FILE" ] && grep -q 'status=self_suppress' "$LOG_FILE"; then
+  fail "T13b unexpected self_suppress log (repo != self)"
+else
+  pass "T13b no self_suppress log (repo differs from self)"
+fi
+rm -rf "$TD"
+
+# --- Test 13c: ERROR_REPORTER_SELF_REPO env override (fork maintainer use case) ---
+printf '\nTest 13c: ERROR_REPORTER_SELF_REPO env override suppresses on fork\n'
+TD=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+SID="smoke-t13c-$$-$(date +%s)"
+mkdir -p "$TD/markers" "$TD/bin"
+touch "$TD/markers/.v3.1-opt-in-notice.ack"
+make_fake_gh_fatal "$TD/bin"
+INPUT=$(printf '{"hook_event_name":"StopFailure","session_id":"%s","error":"other","cwd":""}' "$SID")
+
+PATH="$TD/bin:$PATH" CLAUDE_PLUGIN_DATA="$TD" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+  ERROR_REPORTER_REPO=myfork/kb-cc-plugin \
+  ERROR_REPORTER_SELF_REPO=myfork/kb-cc-plugin \
+  bash -c "printf '%s' '$INPUT' | bash '$SCRIPT'"
+RC=$?
+[ "$RC" -eq 0 ] && pass "T13c exit 0" || fail "T13c exit $RC"
+sleep 1
+[ ! -f "$TD/gh-was-called" ] && pass "T13c gh NOT invoked (env override works)" \
+  || fail "T13c gh was called — env override broken"
+rm -rf "$TD"
+
 # --- Test 10: Malformed preset (MUST run last — manipulates CLAUDE_PLUGIN_ROOT) ---
 printf '\nTest 10: malformed preset — fail-closed (MUST run last)\n'
 (


### PR DESCRIPTION
## Summary

Addresses #28 — adds a repo-equality self-suppression guard so that editing `error-reporter` source does not trigger the reporter to file GitHub Issues against the same repo being edited. Phase 0's CWD-aware targeting made this live; currently benign (0 auto-issues in-repo) but critical once EPIC #20 parallel-teammate PRs touch `scripts/report.sh`.

## Changes

**Guard in `scripts/report.sh`** (+11 lines, after `_resolve_repo`)

- New constant `SELF_REPO="${ERROR_REPORTER_SELF_REPO:-pmmm114/kb-cc-plugin}"` — hardcoded canonical repo with env override for forks
- When `REPORT_REPO == SELF_REPO`: emit `status=self_suppress event=<E> sid=<sid> cwd_repo=<repo>` breadcrumb and `exit 0` before any `gh` invocation
- Placement is after `_resolve_repo` but before `TRANSCRIPT` read — suppresses regardless of event type (Stop/SubagentStop/StopFailure) or preset state
- Why hardcoded over BASH_SOURCE-based path check (as originally sketched in #28): the cached plugin extract is not a git repo, so `_resolve_repo_from_cwd` on the script directory returns empty in installed contexts. A constant + env override is robust across source tree, worktrees, and installed contexts.

**Tests in `tests/end_to_end_test.sh`** (+69 lines, 3 new scenarios)

- `T13`: `ERROR_REPORTER_REPO=pmmm114/kb-cc-plugin` + fake-fatal gh → `status=self_suppress` logged, gh NOT invoked
- `T13b`: `ERROR_REPORTER_REPO=some/other-repo` → guard does NOT fire, no self_suppress log (regression fence)
- `T13c`: `ERROR_REPORTER_SELF_REPO=myfork/kb-cc-plugin` + matching repo → fork maintainer override works

All three assert via the `[ ! -f "$TD/gh-was-called" ]` sentinel pattern already used by T6b / T9.

## Test Plan

```
bash error-reporter/tests/end_to_end_test.sh
# → Summary: 54 passed, 0 failed

shellcheck --severity=warning error-reporter/scripts/report.sh error-reporter/tests/end_to_end_test.sh
# → 0 errors, 0 warnings (info-level SC2015/SC2016 on pre-existing lines only)
```

- [x] T13 / T13b / T13c added and pass locally
- [x] Pre-existing 51 tests still pass (no regressions)
- [x] shellcheck (CI severity=warning) clean
- [x] `Closes #28` in commit + PR body
- [x] No external-facing API change (env var is additive / fork-only)

## Related

- Closes #28
- Prerequisite for EPIC #20 Wave 1 / Wave 3 / Wave 4 PRs that edit `scripts/report.sh`
- Does not modify hook behavior, preset schema, or label emission