### PR TITLE
ci(workflows): drop paths filters + document ruleset policy (#27 Step 1)

### DIFF
--- a/.github/RULESET-POLICY.md
+++ b/.github/RULESET-POLICY.md
@@ -1,0 +1,79 @@
+# Branch Ruleset Policy
+
+This repository uses GitHub branch rulesets to enforce CI gating on protected
+branches. This document records the policy so that future contributors know
+how to add workflows without breaking the gate.
+
+## Protected branches
+
+- `main`
+- `develop` (exact match — not `develop/**`)
+- `base/**` (glob — for release-train branches)
+
+## Required status checks
+
+The ruleset requires ALL of the following to pass before merge:
+
+| Context                              | Workflow                             | integration_id |
+|--------------------------------------|--------------------------------------|----------------|
+| `ShellCheck`                         | `.github/workflows/shellcheck.yml`   | `15368` (github-actions) |
+| `error-reporter end-to-end smoke`    | `.github/workflows/tests.yml`        | `15368` (github-actions) |
+
+`integration_id: 15368` pins the check to the GitHub Actions app, preventing
+a third-party app from spoofing a check-run with a matching name.
+
+## Other rules
+
+- **Pull-request required**: `required_approving_review_count: 0` (solo
+  maintainer; CI is the gate, not human review).
+- **`allowed_merge_methods: ["squash"]`**: every merge is a squash commit.
+  Preserves a linear history and keeps release-note generation simple.
+- **`non_fast_forward: true`**: prevents force-pushes to protected branches.
+- **`bypass_actors: []`**: no admin bypass — the maintainer follows the same
+  gate as everyone else.
+
+## Adding a new PR-triggered workflow
+
+**Every new workflow that gates merges MUST be added to the ruleset's
+`required_status_checks` list.** Otherwise GitHub does not know to wait
+for it, and a PR can merge even if the new workflow is failing.
+
+Procedure:
+
+1. Add the workflow under `.github/workflows/<name>.yml`. Include `on: push`
+   and `on: pull_request` WITHOUT `paths:` filters — the ruleset's
+   `strict_required_status_checks_policy` expects checks to report on every
+   PR, and `paths:` filters cause "Expected — Waiting for status to be
+   reported" blocks.
+2. Note the `name:` (or the job's `name:` if using matrix). That string is
+   the `context` field the ruleset will match.
+3. Update the ruleset via:
+   ```bash
+   gh api repos/pmmm114/kb-cc-plugin/rulesets/<RULESET_ID> --method PATCH \
+     --input <new-required-status-checks.json>
+   ```
+   (or via the Repository → Rules UI on GitHub).
+4. Land the PR that adds the workflow. Verify the new check appears on the
+   next PR's merge-queue view.
+
+## Workflows explicitly NOT in the gate
+
+- `plugin-label.yml` — triggered by `issues` events, never `pull_request`.
+  Adding it to `required_status_checks` would cause PRs to wait forever for
+  a check-run that only fires on issue creation.
+
+## Rollback
+
+If the ruleset breaks merges and needs removal:
+
+```bash
+gh api repos/pmmm114/kb-cc-plugin/rulesets/<RULESET_ID> -X DELETE
+```
+
+Delete the ruleset first, then classic branch protection (if any). The
+inventory of live protections can always be captured via:
+
+```bash
+gh api repos/pmmm114/kb-cc-plugin/branches/main/protection > classic.json
+gh api repos/pmmm114/kb-cc-plugin/rulesets > rulesets.json
+```

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,14 +1,13 @@
 name: shellcheck
 
+# PR-gating workflow. Runs on every push/pull-request per RULESET-POLICY.md —
+# `paths:` filters are intentionally omitted so every PR produces the
+# `ShellCheck` check required by the branch ruleset. Repo-wide *.sh scan
+# completes in ~5s.
+
 on:
   push:
-    paths:
-      - '**/*.sh'
-      - '.github/workflows/shellcheck.yml'
   pull_request:
-    paths:
-      - '**/*.sh'
-      - '.github/workflows/shellcheck.yml'
 
 jobs:
   shellcheck:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,13 @@
 name: tests
 
+# PR-gating workflow. Runs on every push/pull-request per RULESET-POLICY.md —
+# `paths:` filters are intentionally omitted so every PR produces the
+# `error-reporter end-to-end smoke` check required by the branch ruleset.
+# The tests are fast (<45s) so the cost of repo-wide execution is acceptable.
+
 on:
   push:
-    paths:
-      - 'error-reporter/**'
-      - '.github/workflows/tests.yml'
   pull_request:
-    paths:
-      - 'error-reporter/**'
-      - '.github/workflows/tests.yml'
 
 jobs:
   error-reporter-smoke:


### PR DESCRIPTION
## Summary

Implements Step 1 of #27 — removes `paths:` filters from the two PR-gating workflows so every PR produces both required check-runs, unblocking the branch ruleset that will be applied in Wave 6 (Step 2).

Also adds `.github/RULESET-POLICY.md` documenting the full policy (protected branches, required contexts with `integration_id: 15368`, squash-only merge method, and the procedure for adding new PR-triggered workflows).

## Why

GitHub branch rulesets with `strict_required_status_checks_policy` treat missing check-runs as "Expected — Waiting for status to be reported" and block merge indefinitely. Before the ruleset is applied (Wave 6), the required workflows (`tests.yml`, `shellcheck.yml`) must be guaranteed to report on every PR — hence the filter removal.

## Changes

**`.github/workflows/tests.yml`**
- Drop `paths:` on both `push:` and `pull_request:` (previously: `error-reporter/**` + self-path)
- Workflow still runs the same 4 jobs (e2e smoke + 3 unit tests). Wall time ~45s.
- Header comment added linking to `RULESET-POLICY.md`.

**`.github/workflows/shellcheck.yml`**
- Drop `paths:` on both `push:` and `pull_request:` (previously: `**/*.sh` + self-path)
- Repo-wide shellcheck scan at `severity: warning`. Wall time ~5s.
- Header comment added linking to `RULESET-POLICY.md`.

**`.github/RULESET-POLICY.md`** (new, 79 lines)
- Protected branches: `main`, `develop` (exact), `base/**` (glob)
- Required checks: `ShellCheck`, `error-reporter end-to-end smoke` (both pinned to github-actions app via `integration_id: 15368`)
- Merge method: squash only
- Rules: `non_fast_forward: true`, `required_approving_review_count: 0`, no admin bypass
- Procedure: how to add a new PR-triggered workflow to the ruleset
- Explicitly notes `plugin-label.yml` is NOT in the gate (issues-event only)
- Rollback recipe

## Side effects

After merge, every PR (including dashboard-only changes that previously skipped `tests.yml`) will run both workflows. Cost tradeoff:
- +45s CI time on each PR that wasn't touching `error-reporter/**`
- Enables the ruleset to be applied in Wave 6 without "waiting forever" deadlock

The inverse (keeping `paths:`) would require the ruleset to use `strict: false` which defeats the purpose of having required checks.

## Test Plan

No application code changed — workflow behavior is the change itself. Verification is meta: this PR must produce both check-runs (ShellCheck + error-reporter end-to-end smoke) because its diff touches both workflow files.

- [x] `paths:` fully removed from both workflows
- [x] Both workflows still have unchanged jobs (smoke + units, shellcheck scan)
- [x] `RULESET-POLICY.md` documents `integration_id: 15368` for spoof resistance
- [x] `RULESET-POLICY.md` flags `plugin-label.yml` exclusion
- [ ] After merge: Wave 6 will apply the new ruleset and delete the two existing rulesets (`14676432`, `14676392`) + classic branch protection — **not part of this PR**

## Related

- Part of #27
- Step 2 (apply ruleset) and Step 3 (delete legacy protection) to follow in Wave 6 as user-direct operations
- Does not modify any application/error-reporter code