### PR TITLE
feat(error-reporter): rate-limit silent_skip breadcrumb per session per hour (#26)

### DIFF
--- a/error-reporter/README.md
+++ b/error-reporter/README.md
@@ -84,11 +84,12 @@ resolved, or `CLAUDE_PLUGIN_ROOT` is unset — useful for onboarding checks
 and CI integration.
 
 **Upgrader note (3.0.x / 3.1.x → 3.2)**: after upgrade, `error-reporter.log`
-gains a `status=silent_skip reason=preset_not_loaded` line **per Stop /
-SubagentStop event** (not just the one-shot `opt_in_notice`) until a preset
-is configured. This is intentional — it surfaces the preset-unset state to
-on-call. Configure `ERROR_REPORTER_PRESET=claude-harness` to silence the
-breadcrumb.
+gains a `status=silent_skip reason=preset_not_loaded` line **at most once
+per session per hour** while a preset is unconfigured. Rate-limiting (#26)
+ensures Stop-heavy sessions cannot flood the 1000-line ring buffer.
+The `opt_in_notice` one-shot is unchanged and still fires only on the first
+event per install. Configure `ERROR_REPORTER_PRESET=claude-harness` to
+silence both breadcrumbs.
 
 ## 3. Generic mode
 
@@ -326,10 +327,12 @@ intended.
 
 Additional status semantics:
 
-- `silent_skip` — emitted **per event** when `ERROR_REPORTER_PRESET` is unset.
-  Surfaces repeated silent skips to on-call without blocking the hook chain.
-  Coexists with the one-shot `opt_in_notice` (which fires only on the first
-  event until the ack file is deleted).
+- `silent_skip` — emitted **at most once per session per hour** when
+  `ERROR_REPORTER_PRESET` is unset. Hour-bucketed rate limit (#26) via
+  `$MARKER_DIR/.silent_skip.<sid>.<YYYYMMDDHH>` markers prevents log flooding
+  on Stop-heavy sessions. Markers share the 7-day TTL sweep with `*.reported`
+  and `*.lock`. Coexists with the one-shot `opt_in_notice` (which fires only
+  on the first event until the ack file is deleted).
 - `repo_resolution_failed` — appears on `status=fail` rows when all four
   fallbacks (env `ERROR_REPORTER_REPO`, `config.json.repo`, hook-input `.cwd` →
   git remote, preset `.repo` field) yielded an empty result. Logged as

--- a/error-reporter/scripts/report.sh
+++ b/error-reporter/scripts/report.sh
@@ -607,10 +607,17 @@ case "$EVENT" in
     ;;
   Stop|SubagentStop)
     if [ "$PRESET_LOADED" != true ]; then
-      # P0-3: per-event silent_skip breadcrumb so operators can detect silent
-      # loss even after the one-shot opt_in_notice has been ack'd.
-      log_line "$(printf '[%s] status=silent_skip event=%s sid=%s reason=preset_not_loaded' \
-        "$TS" "$EVENT" "$SESSION")"
+      # P0-3 + #26: session/hour-bucketed silent_skip breadcrumb. Emits at
+      # most one line per session per hour so Stop-heavy sessions cannot
+      # flood the 1000-line log ring buffer and displace real status=ok/fail
+      # breadcrumbs. Markers live under $MARKER_DIR/.silent_skip.<sid>.<YYYYMMDDHH>
+      # and are swept by the 7-day TTL find below.
+      SKIP_MARKER="$MARKER_DIR/.silent_skip.${SESSION}.$(date -u +%Y%m%d%H)"
+      if [ ! -f "$SKIP_MARKER" ]; then
+        log_line "$(printf '[%s] status=silent_skip event=%s sid=%s reason=preset_not_loaded' \
+          "$TS" "$EVENT" "$SESSION")"
+        touch "$SKIP_MARKER" 2>/dev/null
+      fi
       # T13: opt-in notice mechanism (one-shot per install).
       # Ack filename keeps the ".v3.1" suffix deliberately so upgraders from 3.1
       # do NOT re-receive the notice on first run of 3.2 (the ack is still valid).
@@ -715,8 +722,9 @@ AGENT_FIELD="$AGENT_ID"
   fi
   trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT
 
-  # Opportunistic sweep of leftovers (7-day TTL).
-  find "$MARKER_DIR" "$LOCK_ROOT" -maxdepth 1 \( -name '*.lock' -o -name '*.reported' \) -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+  # Opportunistic sweep of leftovers (7-day TTL). Includes silent_skip
+  # hour-bucketed markers (#26) alongside lock dirs and reported markers.
+  find "$MARKER_DIR" "$LOCK_ROOT" -maxdepth 1 \( -name '*.lock' -o -name '*.reported' -o -name '.silent_skip.*' \) -mtime +7 -exec rm -rf {} + 2>/dev/null || true
 
   TITLE="[incident] $EVENT${AGENT_ID:+($AGENT_ID)} (${SESSION:0:8})"
 

--- a/error-reporter/tests/end_to_end_test.sh
+++ b/error-reporter/tests/end_to_end_test.sh
@@ -443,6 +443,44 @@ RC=$?
 printf '%s\n' "$OUT" | grep -qF '[FAIL] preset: cannot check (CLAUDE_PLUGIN_ROOT unset)' && pass "T12e FAIL line" || fail "T12e FAIL line"
 rm -rf "$TD"
 
+# --- Test 14: silent_skip rate-limit (#26) ---
+# silent_skip must emit at most once per session per hour. Previously every
+# Stop/SubagentStop event appended a line, which could flood the 1000-line
+# ring buffer on Stop-heavy sessions.
+printf '\nTest 14: silent_skip rate-limited to 1 emit per session per hour\n'
+TD=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+SID="smoke-t14-$$-$(date +%s)"
+mkdir -p "$TD/markers"
+touch "$TD/markers/.v3.1-opt-in-notice.ack"  # suppress notice noise
+INPUT=$(printf '{"hook_event_name":"Stop","session_id":"%s","transcript_path":""}' "$SID")
+
+# Fire 5 events in rapid succession — all within the same UTC hour
+for _ in 1 2 3 4 5; do
+  CLAUDE_PLUGIN_DATA="$TD" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    bash -c "unset ERROR_REPORTER_PRESET ERROR_REPORTER_REPO; printf '%s' '$INPUT' | bash '$SCRIPT'"
+done
+
+sleep 1
+LOG_FILE="$TD/logs/error-reporter.log"
+SKIP_COUNT=$(grep -c 'status=silent_skip' "$LOG_FILE" 2>/dev/null || echo 0)
+[ "$SKIP_COUNT" = "1" ] && pass "T14 5 events → 1 silent_skip log line (rate-limited)" \
+  || fail "T14 expected 1 silent_skip, got $SKIP_COUNT"
+
+HOUR=$(date -u +%Y%m%d%H)
+MARKER="$TD/markers/.silent_skip.${SID}.${HOUR}"
+[ -f "$MARKER" ] && pass "T14 hour-bucketed marker created at expected path" \
+  || fail "T14 marker missing: $MARKER"
+
+# Simulate hour rollover by deleting the marker — next event should emit
+rm -f "$MARKER"
+CLAUDE_PLUGIN_DATA="$TD" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+  bash -c "unset ERROR_REPORTER_PRESET ERROR_REPORTER_REPO; printf '%s' '$INPUT' | bash '$SCRIPT'"
+sleep 1
+SKIP_COUNT_2=$(grep -c 'status=silent_skip' "$LOG_FILE" 2>/dev/null || echo 0)
+[ "$SKIP_COUNT_2" = "2" ] && pass "T14 hour rollover → 2nd silent_skip emitted" \
+  || fail "T14 expected 2 silent_skip after rollover, got $SKIP_COUNT_2"
+rm -rf "$TD"
+
 # --- Test 13: Self-recursion guard (kb-cc-plugin#28) ---
 # When REPORT_REPO resolves to SELF_REPO (pmmm114/kb-cc-plugin), the reporter
 # must emit a breadcrumb and exit without ever invoking gh. Prevents infinite


### PR DESCRIPTION
## Summary

Closes #26. Rate-limits the per-event `status=silent_skip` breadcrumb introduced in PR #25 (P0-3) to **at most one emit per session per hour**, preventing log-ring-buffer flooding on Stop-heavy orchestrations.

## Why

P0-3 emits a silent_skip line on every Stop/SubagentStop event when no preset is configured. Long orchestrations with many subagents can accumulate dozens of lines per session. The `error-reporter.log` ring buffer caps at 1000 lines and trims to 500 keeping only the first line, so real `status=ok` / `status=fail` breadcrumbs get asymmetrically displaced by silent_skip noise.

## Changes

**`scripts/report.sh` — silent_skip guard** (lines ~609-622)

Wraps the existing `log_line` call with an hour-bucketed marker check:

```bash
SKIP_MARKER="$MARKER_DIR/.silent_skip.${SESSION}.$(date -u +%Y%m%d%H)"
if [ ! -f "$SKIP_MARKER" ]; then
  log_line "[$TS] status=silent_skip event=$EVENT sid=$SESSION reason=preset_not_loaded"
  touch "$SKIP_MARKER" 2>/dev/null
fi
```

- UTC hour bucket (`date -u +%Y%m%d%H`) avoids DST/timezone surprises
- Marker path inside `$MARKER_DIR` so cleanup shares the existing plumbing
- First-event-per-hour emits; subsequent events see the marker and skip

**`scripts/report.sh` — 7-day TTL sweep** (line ~723)

Extends the opportunistic sweep to include the new marker pattern:

```diff
-find "$MARKER_DIR" "$LOCK_ROOT" -maxdepth 1 \( -name '*.lock' -o -name '*.reported' \) -mtime +7 ...
+find "$MARKER_DIR" "$LOCK_ROOT" -maxdepth 1 \( -name '*.lock' -o -name '*.reported' -o -name '.silent_skip.*' \) -mtime +7 ...
```

**`README.md` — §2 upgrader note + §7 status semantics**
- Cadence updated from "per event" to "at most once per session per hour"
- Marker path + TTL documented
- `opt_in_notice` one-shot behavior explicitly called out as unchanged

**Not changed**
- `opt_in_notice` path (`.v3.1-opt-in-notice.ack` semantic preserved)
- Early-return structure of the `PRESET_LOADED != true` block (no structural refactor — avoids hunk conflicts with upcoming #22 PR per v4 master plan)
- Log format — same key=value line, just less frequent

## Test Plan

Runs locally:

```
bash error-reporter/tests/end_to_end_test.sh
# → Summary: 57 passed, 0 failed

shellcheck --severity=warning error-reporter/scripts/report.sh error-reporter/tests/end_to_end_test.sh
# → 0 errors, 0 warnings
```

**New Test 14** (3 assertions):
- 5 rapid Stop events in same session → exactly 1 `status=silent_skip` log line (rate-limited)
- Hour-bucketed marker created at `$MARKER_DIR/.silent_skip.<sid>.<YYYYMMDDHH>`
- Marker deletion (hour rollover simulation) → 2nd silent_skip emitted

Pre-existing 54 tests still pass (T11 opt_in_notice dedup still fires once, confirming co-existence).

## Acceptance Criteria (from #26)

- [x] 100 synthetic Stop events in one session → silent_skip appears exactly once (T14 exercises 5 events; same invariant)
- [x] Hour rollover (simulated via marker removal) → new marker, second line emitted
- [x] Existing `opt_in_notice` one-shot logic unchanged (T11 passes unchanged)
- [x] 7-day marker sweep includes `.silent_skip.*` pattern (L723 diff)

## Related

- Closes #26
- Rides on Phase 0 baseline (PR #25)
- Does not conflict with #22 / #24 / #23 (hunks non-overlapping per v4 master plan)