### PR TITLE
fix(error-reporter): reporter:repo:* flatten preserves internal underscores (#33)

### DIFF
--- a/error-reporter/scripts/report.sh
+++ b/error-reporter/scripts/report.sh
@@ -736,9 +736,13 @@ _five_axis_labels() {
   [ -z "$cluster_sig" ] && cluster_sig="unknown00000"
   local cluster_label="reporter:cluster:${cluster_sig}"
   # Repo label flattens owner/repo → owner__repo (GitHub labels disallow /).
+  # Uses sed with '|' delimiter to substitute '/' directly, preserving any
+  # underscores already present in the owner or repo segments. A previous
+  # two-step (tr + sed) transform mis-flattened 'user_name/repo' as
+  # 'user__name_repo' — see #33.
   local repo_flat
   if [ -n "$REPORT_REPO" ]; then
-    repo_flat=$(printf '%s' "$REPORT_REPO" | tr '/' '_' | sed 's/_/__/')
+    repo_flat=$(printf '%s' "$REPORT_REPO" | sed 's|/|__|')
     repo_label="reporter:repo:${repo_flat}"
   else
     repo_label="reporter:repo:unknown"

--- a/error-reporter/tests/end_to_end_test.sh
+++ b/error-reporter/tests/end_to_end_test.sh
@@ -614,6 +614,57 @@ fi
 
 cleanup_session "$SID" "$TD"
 
+# --- Test 15b: reporter:repo:* flatten handles underscores in owner/repo (#33) ---
+# The previous tr+sed transform misfired when owner or repo names contained
+# underscores. This test locks in the corrected behavior across three cases.
+printf '\nTest 15b: reporter:repo:* flatten preserves internal underscores (#33)\n'
+check_repo_flat() {
+  # $1 = REPORT_REPO input, $2 = expected reporter:repo:<flat> label
+  local input="$1" expected_label="$2"
+  local td sid gh_log
+  td=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+  sid="smoke-t15b-$(date +%s%N)-$RANDOM"
+  mkdir -p "$td/markers" "$td/bin"
+  touch "$td/markers/.v3.1-opt-in-notice.ack"
+  cat > "$td/bin/gh" <<'GHFAKE'
+#!/bin/bash
+LOG="${GH_CAPTURE_LOG:-/dev/null}"
+case "$1" in
+  auth) exit 0 ;;
+  label) printf 'LABEL_CREATE: %s\n' "$3" >> "$LOG"; exit 0 ;;
+  issue) exit 0 ;;
+  *) exit 0 ;;
+esac
+GHFAKE
+  chmod +x "$td/bin/gh"
+  gh_log="$td/gh-capture.log"
+  make_synthetic_debug_log "$sid" ""
+  local payload
+  payload=$(printf '{"hook_event_name":"StopFailure","session_id":"%s","error":"other","cwd":""}' "$sid")
+
+  PATH="$td/bin:$PATH" GH_CAPTURE_LOG="$gh_log" \
+    CLAUDE_PLUGIN_DATA="$td" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    ERROR_REPORTER_PRESET=claude-harness ERROR_REPORTER_REPO="$input" \
+    bash -c "printf '%s' '$payload' | bash '$SCRIPT'"
+
+  wait_for_background "$sid" "$td/markers"
+
+  if grep -qF "LABEL_CREATE: ${expected_label}" "$gh_log"; then
+    pass "T15b ${input} → ${expected_label}"
+  else
+    local actual
+    actual=$(grep 'LABEL_CREATE: reporter:repo:' "$gh_log" | head -1)
+    fail "T15b ${input} → expected ${expected_label}, got: ${actual}"
+  fi
+  cleanup_session "$sid" "$td"
+}
+
+# Note: avoid pmmm114/kb-cc-plugin as input — matches SELF_REPO (self-suppression)
+# and would emit no labels. Use distinct owners/repos for the flatten check.
+check_repo_flat "acme-co/simple-repo"  "reporter:repo:acme-co__simple-repo"
+check_repo_flat "user_name/repo"       "reporter:repo:user_name__repo"
+check_repo_flat "acme/my_project"      "reporter:repo:acme__my_project"
+
 # --- Test 10: Malformed preset (MUST run last — manipulates CLAUDE_PLUGIN_ROOT) ---
 printf '\nTest 10: malformed preset — fail-closed (MUST run last)\n'
 (


### PR DESCRIPTION
## Summary

Closes #33. Fixes the `reporter:repo:*` label flatten introduced in #32 (5-axis labels) so that owner or repo names containing underscores produce correct labels.

## The bug

`_five_axis_labels()` flattens `owner/repo` via a two-step transform:

```bash
repo_flat=$(printf '%s' "$REPORT_REPO" | tr '/' '_' | sed 's/_/__/')
```

`sed 's/_/__/'` replaces only the **first** underscore. When the owner name has no underscore, the first `_` in the `tr` output IS the separator, so the result is correct. When the owner name contains an underscore, the wrong character gets doubled:

| Input                  | Old output               | Correct              |
|------------------------|--------------------------|----------------------|
| `pmmm114/kb-cc-plugin` | `pmmm114__kb-cc-plugin` ✅ | `pmmm114__kb-cc-plugin` |
| `user_name/repo`       | `user__name_repo` ❌     | `user_name__repo`    |
| `acme/my_project`      | `acme__my_project` ✅    | `acme__my_project`   |

Impact: `reporter:repo:*` label values corrupted for any fork whose owner contains `_`. No data loss; search/filter breaks for affected repos.

## The fix

Single-step `sed` with `|` delimiter so `/` is substituted literally:

```diff
-repo_flat=$(printf '%s' "$REPORT_REPO" | tr '/' '_' | sed 's/_/__/')
+repo_flat=$(printf '%s' "$REPORT_REPO" | sed 's|/|__|')
```

Preserves internal underscores. Correct for all owner/repo combinations.

## Test coverage

New `tests/end_to_end_test.sh` T15b — 3 fixtures exercising the flatten via the existing fake-gh + `GH_CAPTURE_LOG` mechanism:

| Input                 | Expected label                       |
|-----------------------|--------------------------------------|
| `acme-co/simple-repo` | `reporter:repo:acme-co__simple-repo` |
| `user_name/repo`      | `reporter:repo:user_name__repo`      |
| `acme/my_project`     | `reporter:repo:acme__my_project`     |

**Note on fixture choice**: `pmmm114/kb-cc-plugin` is deliberately NOT used as a T15b input — it matches `SELF_REPO` and triggers self-recursion suppression (from #28) before labels are emitted. Other repos exercise the flatten end-to-end without that short-circuit.

## Test Plan

```
bash error-reporter/tests/end_to_end_test.sh
# → Summary: 67 passed, 0 failed
#   (54 pre-existing + 7 T15 + 3 T15b + 3 T13 + others)

shellcheck --severity=warning error-reporter/scripts/report.sh error-reporter/tests/end_to_end_test.sh
# → 0 warnings
```

- [x] Logic simulation for 3 distinct repo name shapes verified correct
- [x] T15b regression fence blocks any future `tr|sed` style reintroduction
- [x] Inline code comment added explaining why sed-`|` over tr+sed

## Related

- Closes #33
- Bug introduced in #32 (5-axis labels + preset schema v2)
- Discovered via post-merge review