### PR TITLE
feat(error-reporter): incident-to-eval scaffold + draft/flaky fallback (#23 MVP)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,5 @@ jobs:
         run: bash error-reporter/tests/unit_resolve_repo.sh
       - name: verify_preset_equivalence.sh
         run: bash error-reporter/tests/verify_preset_equivalence.sh
+      - name: unit_incident_to_eval.sh
+        run: bash error-reporter/tests/unit_incident_to_eval.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Python bytecode
+__pycache__/
+*.pyc
+*.pyo

--- a/error-reporter/scripts/incident-to-eval.py
+++ b/error-reporter/scripts/incident-to-eval.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""incident-to-eval: scaffold a meta-eval JSON from an auto-filed incident.
+
+Closes the incident → meta-eval gap (<RULE name="no-config-without-eval">).
+Today every incident is human-triaged into a manual eval; this script
+auto-scaffolds a meta-eval JSON from the incident body so triage can
+focus on the `reference_solution.files` rather than boilerplate.
+
+Input: one of --issue <gh-url> | --file <path> | --stdin
+Output: benchmarks/meta-evals/incident-<sid8>.json on stdout unless --out is given
+
+Refuse-to-generate (exit 2): Counterfactual section is empty placeholder.
+This is a deterministic check on the body — does NOT violate HG-9 since
+no eval is created at all, no scoring is affected.
+
+Draft fallback: when reference_solution.files cannot be derived from the
+body, emit the eval with `stability: flaky` + `draft: true` so a human
+must gate it before it contributes to scoring.
+
+Python stdlib only (no third-party deps).
+"""
+from __future__ import annotations
+import argparse
+import json
+import re
+import sys
+import urllib.request
+import urllib.error
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Body parsing
+# ---------------------------------------------------------------------------
+
+COUNTERFACTUAL_PLACEHOLDER_PATTERN = re.compile(
+    r"<!--\s*What SHOULD have happened[^>]*-->",
+    re.IGNORECASE,
+)
+
+TRIGGER_ROW_PATTERN = re.compile(
+    r"^\|\s*`(?P<event>[^`]*)`\s*\|"
+    r"\s*`(?P<hook>[^`]*)`\s*\|"
+    r"\s*`(?P<phase>[^`]*)`\s*\|"
+    r"\s*`(?P<agent>[^`]*)`\s*\|"
+    r"\s*`(?P<severity>[^`]*)`\s*\|"
+    r"\s*`(?P<commit>[^`]*)`\s*\|",
+    re.MULTILINE,
+)
+
+SECTION_PATTERN = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+
+
+@dataclass
+class Incident:
+    """Parsed fields from the issue body. Missing fields → empty strings."""
+    event: str = ""
+    hook: str = ""
+    phase: str = ""
+    agent: str = ""
+    severity: str = ""
+    commit: str = ""
+    counterfactual_filled: bool = False
+    sections: list[str] = field(default_factory=list)
+    raw_body: str = ""
+
+
+def parse_body(body: str) -> Incident:
+    """Extract structured fields from the issue body."""
+    inc = Incident(raw_body=body)
+
+    # Trigger table row
+    m = TRIGGER_ROW_PATTERN.search(body)
+    if m:
+        for name in ("event", "hook", "phase", "agent", "severity", "commit"):
+            val = m.group(name)
+            if val == "—":
+                val = ""
+            setattr(inc, name, val)
+
+    # Section inventory
+    inc.sections = [m.group(1) for m in SECTION_PATTERN.finditer(body)]
+
+    # Counterfactual filled detection: look at the body chunk between
+    # "## Counterfactual" and the next "##" header; if the only meaningful
+    # content is the placeholder HTML comment, treat as empty.
+    cf_match = re.search(
+        r"##\s+Counterfactual\s*\n(.*?)(?=\n##\s+|\Z)",
+        body,
+        re.DOTALL,
+    )
+    if cf_match:
+        cf_body = cf_match.group(1).strip()
+        cf_body_no_placeholder = COUNTERFACTUAL_PLACEHOLDER_PATTERN.sub("", cf_body).strip()
+        inc.counterfactual_filled = bool(cf_body_no_placeholder)
+
+    return inc
+
+
+# ---------------------------------------------------------------------------
+# Input resolution
+# ---------------------------------------------------------------------------
+
+def read_input(args: argparse.Namespace) -> str:
+    """Resolve --issue / --file / --stdin into the raw body text."""
+    if args.issue:
+        return fetch_issue_body(args.issue)
+    if args.file:
+        with open(args.file, "r", encoding="utf-8") as f:
+            return f.read()
+    if args.stdin:
+        return sys.stdin.read()
+    raise SystemExit("one of --issue <url> | --file <path> | --stdin is required")
+
+
+def fetch_issue_body(url: str) -> str:
+    """Fetch issue body via GitHub REST API.
+
+    Accepts either https://github.com/<owner>/<repo>/issues/<n> or
+    https://api.github.com/repos/<owner>/<repo>/issues/<n>.
+    """
+    m = re.match(r"https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)", url)
+    if m:
+        api_url = (
+            f"https://api.github.com/repos/{m.group(1)}/{m.group(2)}"
+            f"/issues/{m.group(3)}"
+        )
+    elif url.startswith("https://api.github.com/"):
+        api_url = url
+    else:
+        raise SystemExit(f"unrecognized issue URL shape: {url}")
+
+    req = urllib.request.Request(
+        api_url,
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"github API error {e.code}: {e.reason}")
+    except urllib.error.URLError as e:
+        raise SystemExit(f"github API unreachable: {e.reason}")
+
+    body = data.get("body")
+    if body is None:
+        raise SystemExit(f"issue has no body: {api_url}")
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Eval construction
+# ---------------------------------------------------------------------------
+
+def derive_tags(inc: Incident) -> list[str]:
+    """Namespaced tags from the incident. Empty fields are skipped."""
+    tags: list[str] = []
+    if inc.hook:
+        hook_stem = inc.hook[:-3] if inc.hook.endswith(".sh") else inc.hook
+        tags.append(f"hook:{hook_stem}")
+    if inc.phase:
+        tags.append(f"phase:{inc.phase}")
+    if inc.severity:
+        tags.append(f"severity:{inc.severity}")
+    if inc.agent:
+        tags.append(f"agent:{inc.agent}")
+    return tags
+
+
+def derive_assertions(inc: Incident) -> list[dict]:
+    """Deterministic assertions only (HG-9 — no score inflation).
+
+    Emits:
+    - tool_was_used / tool_not_used based on EVENT
+    - output_contains for a narrow keyword signal
+    """
+    assertions: list[dict] = []
+    if inc.hook:
+        # The eval transcript MUST mention the hook name somewhere
+        hook_stem = inc.hook[:-3] if inc.hook.endswith(".sh") else inc.hook
+        assertions.append({
+            "type": "output_contains",
+            "expect": hook_stem,
+            "description": f"transcript references `{inc.hook}`",
+        })
+    if inc.event:
+        # The transcript SHOULD show the triggering event at least once
+        assertions.append({
+            "type": "output_contains",
+            "expect": inc.event,
+            "description": f"transcript mentions `{inc.event}` event",
+        })
+    return assertions
+
+
+def build_eval(inc: Incident, issue_sid_hint: Optional[str]) -> tuple[dict, list[str]]:
+    """Build the meta-eval JSON. Returns (eval_dict, warnings)."""
+    warnings: list[str] = []
+
+    sid8 = issue_sid_hint or extract_sid8(inc)
+    eval_id = f"incident-{sid8}"
+
+    tags = derive_tags(inc)
+    assertions = derive_assertions(inc)
+
+    # Draft flag + flaky stability when we cannot derive reference solution.
+    # The current MVP always marks as draft/flaky because deriving a fully
+    # automated reference_solution from prose is unreliable — follow-ups can
+    # harden specific hook patterns (test-driven inversion).
+    draft = True
+    warnings.append(
+        "draft:true + stability:flaky because reference_solution.files "
+        "cannot be derived automatically in MVP. A human must gate this "
+        "eval before it contributes to scoring."
+    )
+
+    eval_obj: dict = {
+        "id": eval_id,
+        "description": _description(inc),
+        "tags": tags,
+        "prompt": _prompt(inc),
+        "workspace_files": {},
+        "assertions": assertions,
+        "reference_solution": {
+            "description": (
+                "See the original incident issue body. Reviewer should fill "
+                "in the minimum file state that satisfies the assertions "
+                "above before removing `draft: true`."
+            ),
+            "files": {},
+        },
+        "config": {
+            "trials": 1,
+            "max_turns": 8,
+            "max_budget_usd": 0.2,
+            "model": "haiku",
+        },
+        "stability": "flaky",
+        "draft": draft,
+    }
+    return eval_obj, warnings
+
+
+def _description(inc: Incident) -> str:
+    parts = ["Incident-derived eval."]
+    if inc.hook:
+        parts.append(f"Fired from `{inc.hook}`.")
+    if inc.phase:
+        parts.append(f"Session phase at time of deny: `{inc.phase}`.")
+    if inc.severity:
+        parts.append(f"Severity classification: `{inc.severity}`.")
+    return " ".join(parts)
+
+
+def _prompt(inc: Incident) -> str:
+    """Generate a prompt that re-creates the conditions of the incident."""
+    pieces = [
+        "Investigate the following incident pattern and demonstrate the correct handling.",
+    ]
+    if inc.event and inc.hook:
+        pieces.append(f"Reproduce conditions that fire `{inc.hook}` on `{inc.event}`.")
+    if inc.phase:
+        pieces.append(f"Current session phase: `{inc.phase}`.")
+    pieces.append(
+        "Your output transcript must reference the hook name above at least once."
+    )
+    return "\n\n".join(pieces)
+
+
+def extract_sid8(inc: Incident) -> str:
+    """Best-effort 8-char session-id extractor from the commit field or title-like content."""
+    if inc.commit and re.match(r"^[0-9a-f]+$", inc.commit):
+        return inc.commit[:8]
+    # Look for `(xxxxxxxx)` token in the body (matches title format from report.sh)
+    m = re.search(r"\(([0-9a-f]{8})\)", inc.raw_body)
+    if m:
+        return m.group(1)
+    return "unknown0"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scaffold a meta-eval JSON from an auto-filed incident.",
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--issue", help="GitHub issue URL")
+    src.add_argument("--file", help="local file containing the issue body")
+    src.add_argument("--stdin", action="store_true", help="read body from stdin")
+    parser.add_argument("--out", help="write output to file (default: stdout)")
+    parser.add_argument(
+        "--sid",
+        help="override session-id hint used for the eval id",
+    )
+    parser.add_argument(
+        "--allow-empty-counterfactual",
+        action="store_true",
+        help=(
+            "skip the empty-counterfactual refuse-to-generate guard. "
+            "Use only when back-filling historical incidents."
+        ),
+    )
+    args = parser.parse_args()
+
+    body = read_input(args)
+    inc = parse_body(body)
+
+    # Refuse-to-generate guard: empty Counterfactual section is a hard exit 2.
+    if not inc.counterfactual_filled and not args.allow_empty_counterfactual:
+        print(
+            "refuse-to-generate: `## Counterfactual` section is empty or contains only the placeholder comment.\n"
+            "Fill it in (describe what SHOULD have happened) and rerun, or pass --allow-empty-counterfactual for backfills.",
+            file=sys.stderr,
+        )
+        return 2
+
+    eval_obj, warnings = build_eval(inc, args.sid)
+    for w in warnings:
+        print(f"warning: {w}", file=sys.stderr)
+
+    rendered = json.dumps(eval_obj, indent=2) + "\n"
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(rendered)
+        print(f"wrote {args.out}", file=sys.stderr)
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/error-reporter/tests/fixtures/incidents/empty_counterfactual.md
+++ b/error-reporter/tests/fixtures/incidents/empty_counterfactual.md
@@ -1,0 +1,33 @@
+## Trigger
+
+| Event | Hook | Phase | Agent | Severity | Commit |
+|-------|------|-------|-------|----------|--------|
+| `SubagentStop` | `pre-edit-guard.sh` | `verifying` | `editor` | `A2-guard-recovered` | `abc12345` |
+
+## Decisive Entry
+
+```jsonl
+{"ts":"t3","event":"PreToolUse","hook":"pre-edit-guard.sh","decision":"deny","phase":"verifying"}
+```
+
+## Counterfactual
+
+<!-- What SHOULD have happened — fill in manually to make this observation actionable -->
+
+## Base Rates
+
+<!-- TODO #24 follow-up: deny/total ratio -->
+
+## Related Meta-Eval
+
+<!-- TODO #24 follow-up: pointer -->
+
+## Known Drift Match
+
+<!-- TODO #24 follow-up: auto-grep -->
+
+## Reproduction
+
+```bash
+/kb-harness --from-incident <this-issue-number> --target $HOME/.claude-harness
+```

--- a/error-reporter/tests/fixtures/incidents/filled_valid.md
+++ b/error-reporter/tests/fixtures/incidents/filled_valid.md
@@ -1,0 +1,36 @@
+## Trigger
+
+| Event | Hook | Phase | Agent | Severity | Commit |
+|-------|------|-------|-------|----------|--------|
+| `SubagentStop` | `pre-edit-guard.sh` | `verifying` | `editor` | `A2-guard-recovered` | `def67890` |
+
+## Decisive Entry
+
+```jsonl
+{"ts":"t3","event":"PreToolUse","hook":"pre-edit-guard.sh","decision":"deny","phase":"verifying"}  ← decisive
+```
+
+## Counterfactual
+
+The editor agent should have entered the `verifying` phase only after the
+plan was explicitly marked complete. Instead it triggered `pre-edit-guard`
+while still in `reviewing`, indicating a phase-transition race with the
+orchestrator.
+
+## Base Rates
+
+<!-- TODO -->
+
+## Related Meta-Eval
+
+<!-- TODO -->
+
+## Known Drift Match
+
+<!-- TODO -->
+
+## Reproduction
+
+```bash
+/kb-harness --from-incident 42 --target $HOME/.claude-harness
+```

--- a/error-reporter/tests/fixtures/incidents/no_trigger_table.md
+++ b/error-reporter/tests/fixtures/incidents/no_trigger_table.md
@@ -1,0 +1,12 @@
+# Legacy issue body (pre-#24 format)
+
+This body has no Trigger table — it predates the body restructure in PR #35.
+incident-to-eval should still be able to handle it gracefully by extracting
+whatever fields it can and producing a draft eval.
+
+## Counterfactual
+
+The reporter should have filed this with the current body schema. The
+absence of the Trigger table means tag inference is limited, but the tool
+should still scaffold an eval with an empty tags list and the raw body as
+context.

--- a/error-reporter/tests/unit_incident_to_eval.sh
+++ b/error-reporter/tests/unit_incident_to_eval.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# unit_incident_to_eval.sh
+#
+# Exercises scripts/incident-to-eval.py against the fixtures under
+# tests/fixtures/incidents/ and asserts the documented behavior:
+#
+# 1. Empty Counterfactual → exit 2 refuse-to-generate
+# 2. Filled Counterfactual → exit 0 + valid JSON + expected tags
+# 3. Missing Trigger table → exit 0 + empty tags + still a draft eval
+# 4. --allow-empty-counterfactual bypass → exit 0 even on empty CF
+# 5. Missing input flag → argparse error exit
+# 6. JSON is parseable and has required top-level fields
+# 7. stability:flaky + draft:true present (MVP always marks as draft)
+# 8. Tag format: hook:<stem> / phase:<p> / severity:<s> / agent:<a>
+
+set +e
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/error-reporter/scripts/incident-to-eval.py"
+FX="$REPO_ROOT/error-reporter/tests/fixtures/incidents"
+
+PASS=0
+FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+command -v python3 >/dev/null 2>&1 || { echo "FATAL: python3 required" >&2; exit 1; }
+[ -f "$SCRIPT" ] || { echo "FATAL: script not found: $SCRIPT" >&2; exit 1; }
+
+# --- Case 1: empty Counterfactual → exit 2 refuse-to-generate ---
+OUT=$(python3 "$SCRIPT" --file "$FX/empty_counterfactual.md" 2>&1)
+RC=$?
+[ "$RC" -eq 2 ] && pass "Case 1 exit 2 on empty Counterfactual" \
+  || fail "Case 1 expected exit 2, got $RC"
+printf '%s\n' "$OUT" | grep -q 'refuse-to-generate' \
+  && pass "Case 1 stderr mentions refuse-to-generate" \
+  || fail "Case 1 stderr missing refuse-to-generate"
+
+# --- Case 2: filled Counterfactual → exit 0, JSON, expected tags ---
+TMP=$(mktemp "/tmp/iteval-XXXXXX.json")
+python3 "$SCRIPT" --file "$FX/filled_valid.md" --out "$TMP" 2>/dev/null
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 2 exit 0 on filled CF" || fail "Case 2 exit $RC"
+if [ -s "$TMP" ]; then
+  python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$TMP" 2>/dev/null \
+    && pass "Case 2 output is valid JSON" \
+    || fail "Case 2 output is not valid JSON"
+  python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get('id','').startswith('incident-') else 1)" "$TMP" \
+    && pass "Case 2 id starts with 'incident-'" \
+    || fail "Case 2 id does not start with incident-"
+  python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if 'hook:pre-edit-guard' in d.get('tags',[]) else 1)" "$TMP" \
+    && pass "Case 2 tags include hook:pre-edit-guard (stem, no .sh)" \
+    || fail "Case 2 missing hook:pre-edit-guard tag"
+  python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get('stability')=='flaky' and d.get('draft') is True else 1)" "$TMP" \
+    && pass "Case 2 stability:flaky + draft:true (MVP)" \
+    || fail "Case 2 missing stability/draft markers"
+  python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get('config',{}).get('max_budget_usd')==0.2 else 1)" "$TMP" \
+    && pass "Case 2 config.max_budget_usd=0.2" \
+    || fail "Case 2 config.max_budget_usd mismatch"
+else
+  fail "Case 2 output file empty"
+fi
+rm -f "$TMP"
+
+# --- Case 3: missing Trigger table → exit 0, empty tags ---
+TMP=$(mktemp "/tmp/iteval-XXXXXX.json")
+python3 "$SCRIPT" --file "$FX/no_trigger_table.md" --out "$TMP" 2>/dev/null
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 3 exit 0 on missing Trigger table" || fail "Case 3 exit $RC"
+if [ -s "$TMP" ]; then
+  python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get('tags',[])==[] else 1)" "$TMP" \
+    && pass "Case 3 tags empty when Trigger table missing" \
+    || fail "Case 3 tags non-empty unexpectedly"
+  python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get('draft') is True else 1)" "$TMP" \
+    && pass "Case 3 still marked draft:true" \
+    || fail "Case 3 draft flag missing"
+else
+  fail "Case 3 output file empty"
+fi
+rm -f "$TMP"
+
+# --- Case 4: --allow-empty-counterfactual bypass ---
+TMP=$(mktemp "/tmp/iteval-XXXXXX.json")
+python3 "$SCRIPT" --file "$FX/empty_counterfactual.md" --allow-empty-counterfactual --out "$TMP" 2>/dev/null
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 4 --allow-empty-counterfactual bypasses refuse-to-generate" \
+  || fail "Case 4 exit $RC with bypass flag"
+rm -f "$TMP"
+
+# --- Case 5: no input source → argparse error ---
+python3 "$SCRIPT" 2>/dev/null
+RC=$?
+[ "$RC" -ne 0 ] && pass "Case 5 missing input source exits non-zero" \
+  || fail "Case 5 expected non-zero exit on missing source"
+
+# --- Case 6: --stdin input path ---
+TMP=$(mktemp "/tmp/iteval-XXXXXX.json")
+cat "$FX/filled_valid.md" | python3 "$SCRIPT" --stdin --out "$TMP" 2>/dev/null
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 6 --stdin input exits 0" || fail "Case 6 --stdin exit $RC"
+[ -s "$TMP" ] && pass "Case 6 --stdin produces output" || fail "Case 6 --stdin no output"
+rm -f "$TMP"
+
+# --- Case 7: --sid override ---
+TMP=$(mktemp "/tmp/iteval-XXXXXX.json")
+python3 "$SCRIPT" --file "$FX/filled_valid.md" --sid "cafef00d" --out "$TMP" 2>/dev/null
+if [ -s "$TMP" ]; then
+  python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get('id')=='incident-cafef00d' else 1)" "$TMP" \
+    && pass "Case 7 --sid override produces incident-<sid>" \
+    || fail "Case 7 --sid override not applied"
+fi
+rm -f "$TMP"
+
+# --- Case 8: assertions structure (deterministic only per HG-9) ---
+TMP=$(mktemp "/tmp/iteval-XXXXXX.json")
+python3 "$SCRIPT" --file "$FX/filled_valid.md" --out "$TMP" 2>/dev/null
+if [ -s "$TMP" ]; then
+  python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+a = d.get('assertions', [])
+# Every assertion must have 'type' field
+if not all('type' in x for x in a): sys.exit(1)
+# Every assertion type must be from the HG-9 deterministic allowlist
+allowed = {'file_contains','not_file_contains','output_contains','output_not_contains','tool_was_used','tool_not_used','file_exists','max_files_changed','tool_call_count'}
+if not all(x['type'] in allowed for x in a): sys.exit(2)
+# Must have at least one assertion
+if len(a) == 0: sys.exit(3)
+" "$TMP"
+  RC=$?
+  case "$RC" in
+    0) pass "Case 8 all assertions have type field + are deterministic + ≥1 exists" ;;
+    1) fail "Case 8 assertion missing type field" ;;
+    2) fail "Case 8 assertion uses non-deterministic type (HG-9 violation)" ;;
+    3) fail "Case 8 no assertions generated" ;;
+    *) fail "Case 8 unexpected exit $RC" ;;
+  esac
+fi
+rm -f "$TMP"
+
+printf '\nSummary: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

EPIC #20 **Phase 3 (MVP)** — ships `scripts/incident-to-eval.py`, a Python stdlib-only scaffolder that converts an auto-filed incident (`auto:hook-failure` issue) into a meta-eval JSON stub. Closes the incident → meta-eval gap flagged by `<RULE name="no-config-without-eval">`: triage now gets a structured starting point instead of boilerplate work.

Refuse-to-generate on empty Counterfactual (hard gate, exit 2) and MVP-wide `draft:true + stability:flaky` keep HG-9 intact — no eval can contribute to scoring until a human gates the reference solution.

## Changes

### `scripts/incident-to-eval.py` (new, 336 lines, Python stdlib only)

**Input resolution** (mutually-exclusive flags)
- `--issue <gh-url>` — fetches body via GitHub REST API (public issues work unauthenticated; private needs `GH_TOKEN`)
- `--file <path>` — local file
- `--stdin` — pipe input (compose with `gh issue view N --json body -q .body | ...`)

**Body parsing**
- Trigger table row (#24) parsed via a 6-column anchored regex → populates `event`, `hook`, `phase`, `agent`, `severity`, `commit`
- `## Counterfactual` section emptiness check — bodies containing only the placeholder HTML comment treated as empty (refuse-to-generate)
- Section-header inventory kept for future enrichment

**Refuse-to-generate gate**
- Empty Counterfactual → **exit 2** with stderr hint
- `--allow-empty-counterfactual` flag for historical backfills (e.g. #82, #83, #84 smoke fixtures)
- Does NOT violate HG-9 — no eval is created at all when refused

**Auto-fill**

| Field | Source |
|-------|--------|
| `id` | `incident-<sid8>` (from commit hex or title tag) |
| `tags` | `hook:<stem>`, `phase:<p>`, `severity:<s>`, `agent:<a>` (empty fields skipped) |
| `prompt` | Synthesized from event+hook+phase |
| `assertions` | `output_contains: <hook-stem>`, `output_contains: <event>` (deterministic only per HG-9) |
| `workspace_files` | `{}` (human fills) |
| `reference_solution.files` | `{}` (human fills) |
| `config` | `{trials:1, max_turns:8, max_budget_usd:0.2, model:haiku}` |
| `stability` | `"flaky"` |
| `draft` | `true` |

### `tests/unit_incident_to_eval.sh` (new, 17 assertions across 8 cases)

| Case | Assertion |
|-----:|-----------|
| 1 | empty Counterfactual → exit 2 + stderr hint |
| 2 | filled Counterfactual → exit 0 + valid JSON + `hook:pre-edit-guard` tag + `stability:flaky` + `draft:true` + `max_budget_usd=0.2` |
| 3 | missing Trigger table → exit 0 + empty tags + draft preserved |
| 4 | `--allow-empty-counterfactual` bypass works |
| 5 | no input source → non-zero argparse error |
| 6 | `--stdin` input path produces output |
| 7 | `--sid` override produces `incident-<sid>` |
| 8 | every assertion type is from the HG-9 deterministic allowlist |

### `tests/fixtures/incidents/` (new, 3 fixtures)
- `empty_counterfactual.md` — Trigger table present, CF stub only (exercises refuse-to-generate)
- `filled_valid.md` — fully filled body exercising the happy path
- `no_trigger_table.md` — legacy body shape (pre-#24) for graceful degradation

### `.github/workflows/tests.yml`
Adds `unit_incident_to_eval.sh` as a step so CI exercises the scaffolder on every PR. Inherits the existing `error-reporter end-to-end smoke` check required by the branch ruleset.

### `.gitignore` (new)
This repo was pure bash until now. The new `.py` file brings `__pycache__/` into play — ignore it and common Python bytecode extensions.

## Test Plan

```
bash error-reporter/tests/end_to_end_test.sh          # → 83 passed (unchanged)
bash error-reporter/tests/unit_preset_helpers.sh      # → 17 passed (unchanged)
bash error-reporter/tests/verify_preset_equivalence.sh # →  9 passed (unchanged)
bash error-reporter/tests/unit_resolve_repo.sh        # → 24 passed (unchanged)
bash error-reporter/tests/unit_incident_to_eval.sh    # → 17 passed  ← new

python3 -m py_compile error-reporter/scripts/incident-to-eval.py  # clean
shellcheck --severity=warning error-reporter/tests/unit_incident_to_eval.sh  # clean
```

Grand total: **150 assertions, 0 failures**.

## Scope deferred (follow-up PRs per v4 master plan)

- **Test-driven inversion** for automatic `reference_solution.files` derivation. MVP always emits draft+flaky so a human gates; future work can harden specific hook patterns.
- **`.github/workflows/incident-staleness.yml`** — cron-scheduled CI WARN when `auto:hook-failure` issues stay unmerged ≥14 days. Runs from default branch, so activation happens after this PR lands.
- **Cluster-level eval generation** — one eval per `reporter:cluster:<sig>`. Phase 5.
- **`--from-incident` retry-loop guard** — belongs with harness-engineering#98 (`/kb-harness --from-incident` skill). Prevents feedback loops where the scaffolded eval re-triggers the same incident.

## Related

- Part of EPIC #20 Phase 3
- Depends on #32 (5-axis labels — `reporter:cluster:*` enables cluster-level evals later)
- Depends on #35 (body 7-section structure — Trigger table row is the parse target; Counterfactual section position is the refuse-to-generate hook)
- Compatible with harness-engineering#98 (`/kb-harness --from-incident <n>` skill — reads the same body shape)