### PR TITLE
feat(error-reporter): ensure-reporter-labels script + weekly label-audit workflow

### DIFF
--- a/.github/workflows/label-audit.yml
+++ b/.github/workflows/label-audit.yml
@@ -1,0 +1,88 @@
+name: label-audit
+
+# Weekly cron that counts `reporter:*` labels on the repository and files
+# a warning issue if the total exceeds the policy threshold (≤30). The
+# 5-axis schema in #22 is intentionally bounded — the cluster and repo
+# axes accrete values over time, so this workflow catches runaway growth
+# before dashboards become unusable.
+#
+# Policy: see .github/RULESET-POLICY.md (#27, #30) for the broader CI
+# governance. This workflow is NOT in the branch ruleset's
+# required_status_checks — it runs on a cron, not on PRs.
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'    # Monday 00:00 UTC
+  workflow_dispatch:        # allow manual trigger for ad-hoc audits
+
+permissions:
+  issues: write              # file the warning issue when threshold breached
+  contents: read
+
+jobs:
+  audit:
+    name: reporter:* label audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Count reporter:* labels
+        id: count
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # gh label list returns tab-separated name/description/color.
+          # Filter to labels starting with "reporter:" and count unique names.
+          REPORTER_LABELS=$(gh label list --repo "${{ github.repository }}" --limit 200 --json name --jq '.[] | .name' | grep -c '^reporter:' || true)
+          echo "count=$REPORTER_LABELS" >> "$GITHUB_OUTPUT"
+          echo "Found $REPORTER_LABELS reporter:* labels"
+      - name: Warn if threshold exceeded
+        if: steps.count.outputs.count > 30
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COUNT: ${{ steps.count.outputs.count }}
+        run: |
+          # Idempotency: skip if an open audit-warning issue already exists
+          # this week. Title includes ISO week so re-runs within the same
+          # week don't stack.
+          WEEK_TAG=$(date -u +'%Y-W%V')
+          TITLE="[label-audit] reporter:* label count exceeds policy threshold (week $WEEK_TAG)"
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --search "$TITLE in:title is:open" \
+            --json number \
+            --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Open audit issue already filed for $WEEK_TAG — skipping."
+            exit 0
+          fi
+          BODY="The \`reporter:*\` label count on this repository is **$COUNT**, which exceeds the policy threshold of 30 defined in \`.github/RULESET-POLICY.md\`.
+
+## What this means
+
+The 5-axis label schema (#22) is designed to stay bounded. Runaway growth is usually one of:
+
+- **\`reporter:cluster:*\` fanout** — a code path producing distinct 12-char hashes per incident (hash collision is not the problem; the *input* to the hash is too diverse). Investigate whether the hash input tuple \`hook:phase:severity:agent\` actually clusters related incidents.
+- **\`reporter:repo:*\` accretion** — the plugin has been used against many repos. Prune stale \`reporter:repo:<owner>__<repo>\` labels that no longer correspond to active work.
+- **\`reporter:hook:*\` new hooks** — harness added hooks without updating any schema. Usually benign; acknowledge and close.
+
+## Pruning
+
+\`\`\`bash
+gh label list --repo ${{ github.repository }} --limit 200 --json name --jq '.[] | select(.name | startswith(\"reporter:cluster:\")) | .name'
+# identify stale entries, then:
+gh label delete <name> --repo ${{ github.repository }} --yes
+\`\`\`
+
+## Policy reference
+
+- Audit workflow: \`.github/workflows/label-audit.yml\`
+- Schema source: \`error-reporter/scripts/report.sh\` (function \`_five_axis_labels\`)
+- Originating issue: #22 (5-axis labels)
+
+This is an automated warning. Closing it is fine if you've reviewed the labels and the count is justified for the current usage pattern."
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "$TITLE" \
+            --label "plugin:error-reporter" \
+            --body "$BODY"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,5 @@ jobs:
         run: bash error-reporter/tests/verify_preset_equivalence.sh
       - name: unit_incident_to_eval.sh
         run: bash error-reporter/tests/unit_incident_to_eval.sh
+      - name: unit_ensure_labels.sh
+        run: bash error-reporter/tests/unit_ensure_labels.sh

--- a/error-reporter/scripts/ensure-reporter-labels.sh
+++ b/error-reporter/scripts/ensure-reporter-labels.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# ensure-reporter-labels.sh
+#
+# Pre-create the ENUMERABLE 5-axis labels that error-reporter emits so
+# that runtime `gh label create ... || true` calls never race with the
+# plugin-label.yml workflow or hit GitHub rate limits during a burst of
+# incidents.
+#
+# ENUMERABLE axes:
+#   - reporter:severity:<label>   — derived from presets/claude-harness.json
+#   - reporter:phase:<name>       — hardcoded from hook-lib-core.sh state machine
+#
+# NON-ENUMERABLE axes (deliberately NOT pre-created):
+#   - reporter:hook:<stem>        — open set; any hook file name can fire
+#   - reporter:cluster:<12-hex>   — 48-bit hash, space too large
+#   - reporter:repo:<owner__repo> — per-user repo list, unbounded
+#
+# Idempotent: uses `gh label create ... || true`. Safe to re-run.
+#
+# Usage:
+#   ensure-reporter-labels.sh --repo <owner/repo> [--dry-run]
+#
+# Exit: 0 on success, 1 on argument error, 2 on missing dependencies.
+
+set +e
+
+DRY_RUN=false
+REPO=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      sed -n '3,27p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$REPO" ]; then
+  echo "error: --repo <owner/repo> is required" >&2
+  exit 1
+fi
+
+command -v gh >/dev/null 2>&1 || { echo "error: gh CLI not found" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "error: jq not found" >&2; exit 2; }
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PRESET="$SCRIPT_DIR/../presets/claude-harness.json"
+[ -f "$PRESET" ] || { echo "error: preset not found at $PRESET" >&2; exit 2; }
+
+# --- Severity labels from preset ---
+# severity_rules values: {"StopFailure":{"timeout":"A3-resource","default":"A1-coordination"},"Stop":"A2-guard-recovered",...}
+# Collect every scalar value (leaves of the severity_rules tree).
+SEVERITIES=$(jq -r '
+  .severity_rules
+  | [ .. | strings ]
+  | unique
+  | .[]
+' "$PRESET")
+# Always include "unknown" — emitted when preset unloaded (generic mode).
+SEVERITIES="$SEVERITIES
+unknown"
+
+# --- Phase labels (hardcoded from harness state machine) ---
+# Matches hook-lib-core.sh VALID_TRANSITIONS keys.
+PHASES="idle
+planning
+reviewing
+plan_review
+executing
+verifying
+editing
+config_planning
+config_plan_review
+config_editing
+unknown"
+
+CREATED=0
+SKIPPED=0
+DRY_RUN_NOTED=0
+
+ensure_label() {
+  # $1 = label name, $2 = description, $3 = color (hex no #)
+  local name="$1"
+  local desc="$2"
+  local color="$3"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    printf '  [dry-run] would create: %s (color=%s)\n' "$name" "$color"
+    DRY_RUN_NOTED=$((DRY_RUN_NOTED + 1))
+    return
+  fi
+
+  if gh label create "$name" \
+      --repo "$REPO" \
+      --description "$desc" \
+      --color "$color" 2>/dev/null; then
+    printf '  created: %s\n' "$name"
+    CREATED=$((CREATED + 1))
+  else
+    # Already exists OR transient failure — align with runtime `|| true` semantic
+    printf '  skipped (exists or err): %s\n' "$name"
+    SKIPPED=$((SKIPPED + 1))
+  fi
+}
+
+printf 'ensure-reporter-labels — repo=%s dry_run=%s\n\n' "$REPO" "$DRY_RUN"
+
+printf '=== reporter:severity:* ===\n'
+while IFS= read -r sev; do
+  [ -z "$sev" ] && continue
+  ensure_label "reporter:severity:${sev}" "5-axis severity (error-reporter plugin)" "5319E7"
+done <<EOF
+$SEVERITIES
+EOF
+
+printf '\n=== reporter:phase:* ===\n'
+while IFS= read -r ph; do
+  [ -z "$ph" ] && continue
+  ensure_label "reporter:phase:${ph}" "5-axis phase (error-reporter plugin)" "5319E7"
+done <<EOF
+$PHASES
+EOF
+
+printf '\n---\n'
+if [ "$DRY_RUN" = "true" ]; then
+  printf 'dry-run: %d labels would be created\n' "$DRY_RUN_NOTED"
+else
+  printf 'created: %d, skipped (exists or err): %d\n' "$CREATED" "$SKIPPED"
+fi

--- a/error-reporter/tests/unit_ensure_labels.sh
+++ b/error-reporter/tests/unit_ensure_labels.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# unit_ensure_labels.sh
+#
+# Exercises scripts/ensure-reporter-labels.sh with a fake gh that captures
+# the labels it would create. Verifies:
+#
+# 1. --repo required (exits non-zero without it)
+# 2. --dry-run produces a plan without calling gh label create
+# 3. Severity labels match preset severity_rules values + "unknown"
+# 4. Phase labels match the harness state-machine enumeration
+# 5. Re-run is idempotent (second invocation's gh calls are no-ops
+#    under `|| true` — script still exits 0)
+# 6. Missing preset triggers exit 2 with a clear message
+
+set +e
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/error-reporter/scripts/ensure-reporter-labels.sh"
+
+PASS=0
+FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+[ -x "$SCRIPT" ] || { echo "FATAL: script not executable: $SCRIPT" >&2; exit 1; }
+
+# --- Case 1: --repo missing → exit 1 ---
+OUT=$("$SCRIPT" 2>&1)
+RC=$?
+[ "$RC" -eq 1 ] && pass "Case 1 exit 1 when --repo missing" \
+  || fail "Case 1 expected exit 1, got $RC"
+printf '%s' "$OUT" | grep -q "repo.*required" \
+  && pass "Case 1 stderr mentions --repo required" \
+  || fail "Case 1 missing --repo hint"
+
+# --- Case 2: --dry-run produces plan, no gh calls ---
+TD=$(mktemp -d "/tmp/ensure-labels-XXXXXX")
+mkdir -p "$TD/bin"
+# Fatal fake gh — if invoked, touch sentinel
+cat > "$TD/bin/gh" <<GHFAKE
+#!/bin/bash
+touch "$TD/gh-was-called"
+exit 1
+GHFAKE
+chmod +x "$TD/bin/gh"
+
+PATH="$TD/bin:$PATH" "$SCRIPT" --repo dummy/repo --dry-run > "$TD/plan.out" 2>&1
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 2 --dry-run exits 0" || fail "Case 2 --dry-run exit $RC"
+[ ! -f "$TD/gh-was-called" ] && pass "Case 2 --dry-run does not invoke gh" \
+  || fail "Case 2 --dry-run invoked gh unexpectedly"
+grep -q 'reporter:severity:A1-coordination' "$TD/plan.out" \
+  && pass "Case 2 plan includes reporter:severity:A1-coordination" \
+  || fail "Case 2 plan missing A1-coordination severity"
+grep -q 'reporter:phase:idle' "$TD/plan.out" \
+  && pass "Case 2 plan includes reporter:phase:idle" \
+  || fail "Case 2 plan missing phase:idle"
+grep -q 'reporter:phase:config_planning' "$TD/plan.out" \
+  && pass "Case 2 plan includes reporter:phase:config_planning" \
+  || fail "Case 2 plan missing phase:config_planning"
+rm -rf "$TD"
+
+# --- Case 3: severity enumeration matches preset ---
+# The script derives severities from severity_rules — verify all three classes
+# present (A1/A2/A3) + unknown.
+TD=$(mktemp -d "/tmp/ensure-labels-XXXXXX")
+mkdir -p "$TD/bin"
+cat > "$TD/bin/gh" <<'GHFAKE'
+#!/bin/bash
+printf 'FAKE_GH: %s\n' "$*" >> "$GH_CAPTURE"
+exit 1    # non-zero → script reports "skipped", which is fine here
+GHFAKE
+chmod +x "$TD/bin/gh"
+GH_CAPTURE="$TD/gh-calls.log"
+
+PATH="$TD/bin:$PATH" GH_CAPTURE="$GH_CAPTURE" \
+  "$SCRIPT" --repo test/test >/dev/null 2>&1
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 3 script exits 0 even when fake-gh fails" \
+  || fail "Case 3 exit $RC"
+
+for sev in A1-coordination A2-guard-recovered A3-resource unknown; do
+  if grep -qF "reporter:severity:$sev" "$GH_CAPTURE"; then
+    pass "Case 3 attempted reporter:severity:$sev"
+  else
+    fail "Case 3 missed reporter:severity:$sev"
+  fi
+done
+
+# Phase enumeration — verify all 11 phases + unknown
+for phase in idle planning reviewing plan_review executing verifying editing config_planning config_plan_review config_editing unknown; do
+  if grep -qF "reporter:phase:$phase" "$GH_CAPTURE"; then
+    pass "Case 3 attempted reporter:phase:$phase"
+  else
+    fail "Case 3 missed reporter:phase:$phase"
+  fi
+done
+rm -rf "$TD"
+
+# --- Case 4: idempotent re-run → exit 0 ---
+TD=$(mktemp -d "/tmp/ensure-labels-XXXXXX")
+mkdir -p "$TD/bin"
+# Fake gh that always returns "already exists" (non-zero) — script must
+# treat as benign (skipped counter).
+cat > "$TD/bin/gh" <<'GHFAKE'
+#!/bin/bash
+echo "label already exists" >&2
+exit 1
+GHFAKE
+chmod +x "$TD/bin/gh"
+
+PATH="$TD/bin:$PATH" "$SCRIPT" --repo test/test > "$TD/run1.out" 2>&1
+RC1=$?
+PATH="$TD/bin:$PATH" "$SCRIPT" --repo test/test > "$TD/run2.out" 2>&1
+RC2=$?
+[ "$RC1" -eq 0 ] && [ "$RC2" -eq 0 ] && pass "Case 4 re-runs both exit 0 (idempotent)" \
+  || fail "Case 4 re-run exit $RC1 / $RC2"
+rm -rf "$TD"
+
+# --- Case 5: --help prints usage ---
+OUT=$("$SCRIPT" --help 2>&1)
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 5 --help exits 0" || fail "Case 5 --help exit $RC"
+printf '%s' "$OUT" | grep -q 'Usage' && pass "Case 5 --help shows usage line" \
+  || fail "Case 5 --help missing usage"
+
+printf '\nSummary: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Two T2.A (#32) follow-ups bundled in one PR. Together they close the "label runaway" gap: **proactive bootstrap** (F1) + **passive monitoring** (F3).

## Why

At runtime the reporter creates labels lazily via `gh label create ... || true` — fine for idempotency but susceptible to rate-limit races during bursts and new-label noise on dashboards. The 5-axis schema from #32 is bounded *in principle* (the cluster axis is a finite 48-bit space, the repo axis grows only with usage) but there is no monitor telling us when `reporter:*` label count drifts outside policy. These two artifacts together fix both sides.

## Changes

### 1. `scripts/ensure-reporter-labels.sh` (new, 142 lines)

Pre-creates the ENUMERABLE 5-axis labels once per repo bootstrap:

| Axis | Values | Source |
|------|--------|--------|
| `reporter:severity:<X>` | 4 | `presets/claude-harness.json` `severity_rules` + `unknown` |
| `reporter:phase:<X>` | 11 | Hardcoded from `hook-lib-core.sh` state machine (`idle`, `planning`, `reviewing`, `plan_review`, `executing`, `verifying`, `editing`, `config_planning`, `config_plan_review`, `config_editing`, `unknown`) |

Deliberately does **NOT** pre-create `reporter:hook:*`, `reporter:cluster:*`, `reporter:repo:*` — those are open sets and must be created lazily at runtime.

Key behaviors:
- **Idempotent** — safe to re-run (reuses `gh label create ... || true` semantic)
- `--dry-run` produces a plan without invoking gh
- `--help` prints usage (sed-extracted from header comment)
- Requires `--repo`; validates presence of `gh` + `jq`; exits `1` on arg error, `2` on missing deps

### 2. `.github/workflows/label-audit.yml` (new, 88 lines)

Weekly cron + manual dispatch audit.

- **Trigger**: `cron: '0 0 * * 1'` (Monday 00:00 UTC) + `workflow_dispatch`
- **What it measures**: unique `reporter:*` label count via `gh label list --limit 200`
- **Policy threshold**: 30 (per `.github/RULESET-POLICY.md` §labels — shipped by #30)
- **On breach**: creates a warning issue tagged `plugin:error-reporter` with diagnosis recipes (cluster fanout / repo accretion / new hooks) and pruning commands
- **Idempotent per ISO week**: skips filing if an open audit issue for the current week already exists (prevents re-file storms when the threshold stays breached)
- **Auth**: default `GITHUB_TOKEN` (repo-scoped — sufficient for label list + issue create on same repo)
- **NOT added to the branch ruleset's `required_status_checks`** — cron-only workflow, not a PR gate

### 3. `tests/unit_ensure_labels.sh` (new, 26 assertions)

| Case | What it verifies |
|-----:|------------------|
| 1 | `--repo` missing → exit 1 + stderr hint |
| 2 | `--dry-run` plan includes expected entries + gh NOT invoked (fatal fake-gh with sentinel file) |
| 3 | Severity + phase enumerations match preset/state-machine (4 severities + 11 phases via fake-gh capture log) |
| 4 | Idempotent re-run: second invocation also exits 0 when fake-gh always returns "already exists" |
| 5 | `--help` produces usage text |

### 4. `.github/workflows/tests.yml`

Adds `unit_ensure_labels.sh` as a CI step.

## Test Plan

```
bash error-reporter/tests/end_to_end_test.sh          # → 83 passed (unchanged)
bash error-reporter/tests/unit_preset_helpers.sh      # → 17 passed (unchanged)
bash error-reporter/tests/verify_preset_equivalence.sh # →  9 passed (unchanged)
bash error-reporter/tests/unit_resolve_repo.sh        # → 24 passed (unchanged)
bash error-reporter/tests/unit_incident_to_eval.sh    # → 17 passed (unchanged)
bash error-reporter/tests/unit_ensure_labels.sh       # → 26 passed  ← new

find . -name "*.sh" -not -path "./.git/*" | xargs shellcheck --severity=warning
# → 0 warnings repo-wide
```

Grand total: **176 assertions, 0 failures**.

Manual sanity:
```bash
./error-reporter/scripts/ensure-reporter-labels.sh --repo dummy/repo --dry-run
# prints a 15-label plan (4 severities + 11 phases)
```

## Operational notes

- **First invocation after deploy**: the maintainer runs `ensure-reporter-labels.sh --repo pmmm114/kb-cc-plugin` once (or in CI with a scheduled job — left as a follow-up choice). Subsequent runtime creations become no-ops for the enumerable axes.
- **Weekly audit**: runs automatically every Monday morning UTC. If a warning issue appears, review the `reporter:cluster:*` fanout first (most likely cause of growth).

## Related

- Part of #22 (5-axis labels) follow-up set per v4 master plan
- Rides on #32 (runtime label emission) and #30 (RULESET-POLICY.md policy document)
- Does not affect the branch ruleset (#27) — workflows here are either CI-step additions that already run on every PR OR cron-only (not a PR gate)
- Does not touch harness-engineering — pure kb-cc-plugin code track