### PR TITLE
ci(workflows): weekly incident-staleness cron WARN (#23 T3.A follow-up)

### DIFF
--- a/.github/workflows/incident-staleness.yml
+++ b/.github/workflows/incident-staleness.yml
@@ -1,0 +1,122 @@
+name: incident-staleness
+
+# Weekly cron that flags `auto:hook-failure` issues that have been OPEN
+# ≥14 days without human triage. The staleness bar is conservative: real
+# incidents should get attention within the sprint-length window. If the
+# pile grows, something is systemically wrong (either the reporter is
+# false-positive-ing, or triage capacity is insufficient).
+#
+# Emits a weekly summary issue listing all stale items. NOT a blocking
+# check — intentionally WARN-only per #23 design (CI level B1).
+#
+# Staggered from label-audit.yml (Monday 00:00 UTC) to run at 01:00 UTC
+# so two long-running cron jobs don't contend on the same runner slot.
+
+on:
+  schedule:
+    - cron: '0 1 * * 1'    # Monday 01:00 UTC
+  workflow_dispatch:        # allow manual trigger for ad-hoc staleness checks
+
+permissions:
+  issues: write              # file/update the summary issue
+  contents: read
+
+jobs:
+  staleness:
+    name: auto:hook-failure staleness audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find stale auto:hook-failure issues
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Staleness threshold: 14 days since createdAt
+          CUTOFF_SECONDS=$(( 14 * 24 * 60 * 60 ))
+          NOW_TS=$(date -u +%s)
+
+          # Pull open auto:hook-failure issues with their timestamps
+          STALE_ITEMS=""
+          STALE_COUNT=0
+          while IFS=$'\t' read -r NUMBER TITLE CREATED; do
+            [ -z "$NUMBER" ] && continue
+            # Parse ISO-8601 `createdAt` to epoch seconds (GNU date -d)
+            CREATED_TS=$(date -d "$CREATED" -u +%s 2>/dev/null || echo 0)
+            [ "$CREATED_TS" -eq 0 ] && continue
+            AGE=$((NOW_TS - CREATED_TS))
+            if [ "$AGE" -ge "$CUTOFF_SECONDS" ]; then
+              AGE_DAYS=$((AGE / 86400))
+              STALE_ITEMS="${STALE_ITEMS}- [ ] #${NUMBER} — \"${TITLE}\" (${AGE_DAYS}d old)
+"
+              STALE_COUNT=$((STALE_COUNT + 1))
+            fi
+          done < <(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "auto:hook-failure" \
+            --state open \
+            --limit 200 \
+            --json number,title,createdAt \
+            --jq '.[] | [.number, .title, .createdAt] | @tsv')
+
+          # Export to subsequent steps
+          echo "count=$STALE_COUNT" >> "$GITHUB_OUTPUT"
+          # GITHUB_OUTPUT multi-line: use delimiter pattern
+          {
+            echo "items<<STALE_EOF"
+            printf '%s' "$STALE_ITEMS"
+            echo "STALE_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Found $STALE_COUNT stale auto:hook-failure issues (≥14 days old)"
+
+      - name: File weekly summary if any stale items
+        if: steps.find.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COUNT: ${{ steps.find.outputs.count }}
+          ITEMS: ${{ steps.find.outputs.items }}
+        run: |
+          # Idempotency: skip if an open summary for THIS ISO week exists
+          WEEK_TAG=$(date -u +'%Y-W%V')
+          TITLE="[incident-staleness] ${COUNT} auto:hook-failure issue(s) open ≥14 days (week ${WEEK_TAG})"
+
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --search "in:title \"[incident-staleness]\" \"week ${WEEK_TAG}\" is:open" \
+            --json number \
+            --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Open staleness summary already filed for ${WEEK_TAG} — skipping."
+            exit 0
+          fi
+
+          BODY="The following \`auto:hook-failure\` issues have been open for at least **14 days** without being closed or referenced by a merged PR:
+
+${ITEMS}
+
+## What this means
+
+\`auto:hook-failure\` issues are auto-filed by \`error-reporter\`'s Phase 0/3 pipeline. Each one represents a hook-guard deny that the reporter believes indicates a regression (not a routine routing deny). Letting them accumulate defeats the purpose — either:
+
+- **Real defects** that need triage (close loop: scaffold an eval via \`error-reporter/scripts/incident-to-eval.py\`, then fix the underlying harness or plugin).
+- **False positives** that need filter tuning (update the preset's \`routine_deny_rules\` so the same deny pattern doesn't re-trigger).
+- **Process drift** (the \`## Counterfactual\` section is never getting filled; close with \`not-actionable\` or add to the reporter's ignore list).
+
+## Recommended triage
+
+1. Run \`python3 error-reporter/scripts/incident-to-eval.py --issue <url>\` to scaffold a meta-eval. If it refuses with \`empty Counterfactual\`, fill that section first.
+2. If the incident is no longer actionable, close with a comment explaining why so future audits know it was triaged (not abandoned).
+3. If the class of incident is routine (a guard denying exactly as designed), update the preset's \`routine_deny_rules\` and regenerate any baselines.
+
+## Policy reference
+
+- Workflow: \`.github/workflows/incident-staleness.yml\`
+- Introducing issue: #23 (incident-to-eval)
+- Threshold: 14 days — conservative; lower this when the triage loop stabilizes
+
+This is an automated weekly summary. Close it after triaging the listed items; the next run will refile if fresh stale items appear."
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "$TITLE" \
+            --label "plugin:error-reporter" \
+            --body "$BODY"


### PR DESCRIPTION
## Summary

Ships the CI WARN piece of #23 T3.A that was deferred in PR #36 to keep the main scaffolder PR focused. Weekly cron that flags `auto:hook-failure` issues open ≥14 days and files a single summary issue with triage recipes. WARN-only — **not a blocking gate** per #23 acceptance (CI level B1).

## Why

Without this workflow, `auto:hook-failure` issues accumulate silently — the reporter keeps filing them, there's no pressure to triage, and the queue drifts away from the sprint window it's meant to serve. A weekly nudge creates visibility without turning staleness into a merge blocker.

## Changes

`.github/workflows/incident-staleness.yml` (new, 122 lines)

**Triggers**
- `cron: '0 1 * * 1'` — Monday 01:00 UTC (staggered from `label-audit.yml` at 00:00)
- `workflow_dispatch` — manual trigger for ad-hoc audits

**Logic**
- `gh issue list --label auto:hook-failure --state open` — with `--json number,title,createdAt`
- Age filter: `(now - createdAt) >= 14 * 86400`
- If 0 stale items → exit 0 (no-op)
- If >0 → file a single weekly summary issue

**Idempotency per ISO week**
- Searches for existing `[incident-staleness] ... week YYYY-WVV` open issue
- If present, skip creation (prevents re-file storms when threshold persists)
- A new ISO week → fresh summary

**Auth**
- Default `GITHUB_TOKEN` (repo-scoped, sufficient for issue list + create on same repo)

**Summary issue body**
Includes the stale list as a checkable markdown list plus triage recipes:
1. Scaffold an eval via `error-reporter/scripts/incident-to-eval.py`
2. Close with explanation if not-actionable
3. Tune preset `routine_deny_rules` if systemic false-positive

## What this PR does NOT do

- Does **not** change `error-reporter` runtime behavior — zero impact on emission.
- Does **not** touch the branch ruleset — cron-only workflow, not a PR check.
- Does **not** modify any existing tests or code — pure addition of one YAML file.

## Test Plan

GitHub Actions workflow; will be validated when the file lands (GH parses and reports syntax errors in the Actions UI). Manual dry-run via `workflow_dispatch` after merge to verify the end-to-end flow.

Existing test suite unchanged (176 assertions, all green):

```
bash error-reporter/tests/end_to_end_test.sh         # → 83 passed
bash error-reporter/tests/unit_preset_helpers.sh     # → 17 passed
bash error-reporter/tests/verify_preset_equivalence.sh # →  9 passed
bash error-reporter/tests/unit_resolve_repo.sh       # → 24 passed
bash error-reporter/tests/unit_incident_to_eval.sh   # → 17 passed
bash error-reporter/tests/unit_ensure_labels.sh      # → 26 passed
```

shellcheck `--severity=warning` clean repo-wide.

## Related

- Introducing issue: #23 (incident-to-eval MVP shipped in #36)
- Pairs with #37 (label-audit cron — same idempotency pattern, staggered schedule)
- Not in required_status_checks (ruleset #27) — cron-only workflow