### PR TITLE
feat(error-reporter): retroactive-5axis.sh backfill tool (#22 T2.A follow-up)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,5 +27,7 @@ jobs:
         run: bash error-reporter/tests/verify_preset_equivalence.sh
       - name: unit_incident_to_eval.sh
         run: bash error-reporter/tests/unit_incident_to_eval.sh
+      - name: unit_retroactive_5axis.sh
+        run: bash error-reporter/tests/unit_retroactive_5axis.sh
       - name: unit_ensure_labels.sh
         run: bash error-reporter/tests/unit_ensure_labels.sh

--- a/error-reporter/scripts/retroactive-5axis.sh
+++ b/error-reporter/scripts/retroactive-5axis.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# retroactive-5axis.sh
+#
+# User-local backfill script that applies the 5-axis labels (#22) to
+# historical `auto:hook-failure` issues filed BEFORE the schema rollout.
+# Specifically targets the known smoke-fixture issues that predate
+# PR #32 (5-axis emission) — the claude-harness-engineering repo's
+# #82, #83, #84 issues originally received only the single-axis
+# `reporter:domain:*` label plus `auto:hook-failure`.
+#
+# Intentionally NOT wired into CI — this is a one-shot operator tool
+# run locally with a user PAT that has cross-repo write access. The
+# default GITHUB_TOKEN in a Workflow context cannot edit issues across
+# repositories, so CI-based backfill would silently 403 with the current
+# permissions model.
+#
+# Usage:
+#   retroactive-5axis.sh --dry-run --issues <owner/repo>:<n1,n2,...>
+#   retroactive-5axis.sh --apply --yes-i-mean-it --issues <owner/repo>:<n1,n2,...>
+#
+# Safety defaults:
+#   - --dry-run is the default mode. No writes happen without --apply.
+#   - --apply REQUIRES --yes-i-mean-it to actually mutate issues.
+#   - --remove-old-domain (optional) additionally strips reporter:domain:*
+#     from the target issues. Destructive — off by default.
+#
+# Exit codes:
+#   0 success
+#   1 argument error
+#   2 missing dependency (gh, jq) or auth failure
+#   3 target repo is private and PAT lacks `repo` scope
+#
+# Rate-limit pacing: sleep 2 seconds between issue updates. GitHub core
+# rate limit is 5000/hour, but the `search` endpoint (which `gh issue list`
+# uses internally) has a stricter 30 req/min cap. With 2s pacing we stay
+# well under both thresholds even for multi-hundred-issue batches.
+
+set +e
+
+MODE="dry-run"
+YES=false
+REMOVE_OLD_DOMAIN=false
+ISSUES_ARG=""
+SLEEP_SEC=2
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      MODE="dry-run"
+      shift
+      ;;
+    --apply)
+      MODE="apply"
+      shift
+      ;;
+    --yes-i-mean-it)
+      YES=true
+      shift
+      ;;
+    --remove-old-domain)
+      REMOVE_OLD_DOMAIN=true
+      shift
+      ;;
+    --issues)
+      ISSUES_ARG="$2"
+      shift 2
+      ;;
+    --sleep)
+      SLEEP_SEC="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '3,35p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$ISSUES_ARG" ]; then
+  echo "error: --issues <owner/repo>:<n1,n2,...> is required" >&2
+  exit 1
+fi
+
+# Parse --issues argument
+if ! [[ "$ISSUES_ARG" =~ ^([^/]+)/([^:]+):([0-9,]+)$ ]]; then
+  echo "error: --issues must be in form owner/repo:n1,n2,n3" >&2
+  echo "       e.g. --issues pmmm114/claude-harness-engineering:82,83,84" >&2
+  exit 1
+fi
+OWNER_REPO="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+IFS=',' read -ra ISSUE_NUMBERS <<< "${BASH_REMATCH[3]}"
+
+if [ "$MODE" = "apply" ] && [ "$YES" != "true" ]; then
+  echo "error: --apply requires --yes-i-mean-it as an explicit confirmation flag" >&2
+  echo "       This prevents accidental issue mutation on autocomplete / shell history." >&2
+  exit 1
+fi
+
+command -v gh >/dev/null 2>&1 || { echo "error: gh CLI not found" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "error: jq not found" >&2; exit 2; }
+
+# Verify gh auth
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: gh is not authenticated. Run: gh auth login" >&2
+  exit 2
+fi
+
+# Verify target repo reachable + detect visibility for PAT scope hint
+REPO_VIS=$(gh repo view "$OWNER_REPO" --json isPrivate --jq '.isPrivate' 2>/dev/null)
+if [ -z "$REPO_VIS" ]; then
+  echo "error: cannot reach $OWNER_REPO (404? auth?) — check URL and PAT scopes" >&2
+  exit 3
+fi
+if [ "$REPO_VIS" = "true" ]; then
+  # For private repos, gh PAT needs full `repo` scope (not just public_repo)
+  TOKEN_SCOPES=$(gh auth status 2>&1 | grep -oE "'repo'" | head -1)
+  if [ -z "$TOKEN_SCOPES" ]; then
+    cat >&2 <<EOT
+error: $OWNER_REPO is private but your gh token does not advertise 'repo' scope.
+       Run: gh auth refresh -s repo
+       Then re-run this script.
+EOT
+    exit 3
+  fi
+fi
+
+# --- Inference helpers ---
+# Derive the 5-axis label VALUES for a given issue by parsing its body's
+# Trigger table row (#24 format). Returns the labels on separate lines;
+# empty line if parse failed.
+
+derive_labels_for_issue() {
+  local issue_num="$1"
+  local body
+  body=$(gh issue view "$issue_num" --repo "$OWNER_REPO" --json body --jq '.body' 2>/dev/null)
+  [ -z "$body" ] && return 1
+
+  # Extract Trigger table row — regex mirrors report.sh _five_axis_labels logic
+  # The row shape: | `EVENT` | `HOOK` | `PHASE` | `AGENT` | `SEVERITY` | `COMMIT` |
+  local row
+  row=$(printf '%s' "$body" | grep -m1 -E '^\| `[A-Za-z]+` \| `[^`]+` \|' || true)
+  if [ -z "$row" ]; then
+    # Legacy body shape (pre-#24) — use field-less fallback
+    echo ""
+    return
+  fi
+
+  # Parse cells — only the 4 columns that feed 5-axis labels (event/commit
+  # are in the Trigger table but not part of the 5-axis scheme per #22).
+  local hook phase agent severity
+  hook=$(printf '%s' "$row"     | awk -F '`' '{print $4}')
+  phase=$(printf '%s' "$row"    | awk -F '`' '{print $6}')
+  agent=$(printf '%s' "$row"    | awk -F '`' '{print $8}')
+  severity=$(printf '%s' "$row" | awk -F '`' '{print $10}')
+
+  # Emit labels (empty cells / dash cells skipped)
+  local hook_stem="${hook%.sh}"
+  [ "$hook" = "—" ] && hook_stem=""
+  [ "$phase" = "—" ] && phase=""
+  [ "$severity" = "—" ] && severity=""
+  [ "$agent" = "—" ] && agent=""
+
+  [ -n "$hook_stem" ] && printf 'reporter:hook:%s\n' "$hook_stem"
+  [ -n "$phase" ]     && printf 'reporter:phase:%s\n' "$phase"
+  [ -n "$severity" ]  && printf 'reporter:severity:%s\n' "$severity"
+  # Cluster sig — sha1 of the same input as report.sh _five_axis_labels
+  if [ -n "$hook_stem$phase$severity$agent" ]; then
+    local sig_input sig
+    sig_input="${hook_stem:-none}:${phase:-none}:${severity:-none}:${agent:-none}"
+    sig=$(printf '%s' "$sig_input" | shasum 2>/dev/null | cut -c1-12)
+    [ -n "$sig" ] && printf 'reporter:cluster:%s\n' "$sig"
+  fi
+  # Repo label — the repo this issue lives in (not the CWD repo at emission time)
+  printf 'reporter:repo:%s\n' "$(printf '%s' "$OWNER_REPO" | sed 's|/|__|')"
+  # Agent if present
+  [ -n "$agent" ] && printf 'reporter:agent:%s\n' "$agent"
+}
+
+# --- Main loop ---
+printf 'retroactive-5axis — repo=%s mode=%s remove_old_domain=%s\n' \
+  "$OWNER_REPO" "$MODE" "$REMOVE_OLD_DOMAIN"
+printf 'issues: %s\n' "$(IFS=,; echo "${ISSUE_NUMBERS[*]}")"
+printf 'sleep-per-issue: %ds\n\n' "$SLEEP_SEC"
+
+TOTAL=${#ISSUE_NUMBERS[@]}
+IDX=0
+APPLIED=0
+SKIPPED=0
+FAILED=0
+
+for N in "${ISSUE_NUMBERS[@]}"; do
+  IDX=$((IDX + 1))
+  printf '[%d/%d] issue #%s\n' "$IDX" "$TOTAL" "$N"
+
+  LABELS=$(derive_labels_for_issue "$N")
+  if [ -z "$LABELS" ]; then
+    printf '  skipped: could not derive labels from body (legacy format?)\n'
+    SKIPPED=$((SKIPPED + 1))
+    [ "$IDX" -lt "$TOTAL" ] && sleep "$SLEEP_SEC"
+    continue
+  fi
+
+  # Build the --add-label CSV
+  ADD_CSV=$(printf '%s' "$LABELS" | paste -sd ',' -)
+
+  if [ "$MODE" = "dry-run" ]; then
+    printf '  [dry-run] would add labels: %s\n' "$ADD_CSV"
+    if [ "$REMOVE_OLD_DOMAIN" = "true" ]; then
+      printf '  [dry-run] would remove any existing reporter:domain:* labels\n'
+    fi
+  else
+    # Apply: add labels + optionally remove legacy domain labels
+    if gh issue edit "$N" --repo "$OWNER_REPO" --add-label "$ADD_CSV" 2>/dev/null; then
+      printf '  applied: added %s\n' "$ADD_CSV"
+      APPLIED=$((APPLIED + 1))
+    else
+      printf '  failed: gh issue edit returned non-zero\n'
+      FAILED=$((FAILED + 1))
+      [ "$IDX" -lt "$TOTAL" ] && sleep "$SLEEP_SEC"
+      continue
+    fi
+
+    if [ "$REMOVE_OLD_DOMAIN" = "true" ]; then
+      EXISTING_DOMAINS=$(gh issue view "$N" --repo "$OWNER_REPO" --json labels --jq '.labels[] | select(.name | startswith("reporter:domain:")) | .name' 2>/dev/null)
+      while IFS= read -r DL; do
+        [ -z "$DL" ] && continue
+        if gh issue edit "$N" --repo "$OWNER_REPO" --remove-label "$DL" 2>/dev/null; then
+          printf '  removed legacy: %s\n' "$DL"
+        else
+          printf '  failed to remove: %s\n' "$DL"
+        fi
+      done <<EOF
+$EXISTING_DOMAINS
+EOF
+    fi
+  fi
+
+  [ "$IDX" -lt "$TOTAL" ] && sleep "$SLEEP_SEC"
+done
+
+printf '\n---\n'
+printf 'total=%d applied=%d skipped=%d failed=%d\n' \
+  "$TOTAL" "$APPLIED" "$SKIPPED" "$FAILED"
+
+[ "$FAILED" -gt 0 ] && exit 1
+exit 0

--- a/error-reporter/tests/unit_retroactive_5axis.sh
+++ b/error-reporter/tests/unit_retroactive_5axis.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# unit_retroactive_5axis.sh
+#
+# Exercises scripts/retroactive-5axis.sh argument parsing and label
+# derivation logic. Does NOT actually invoke gh against a real repo —
+# uses a fake gh on PATH that serves canned responses.
+#
+# Test matrix:
+# 1. No args → exit 1
+# 2. --issues missing → exit 1
+# 3. Malformed --issues format → exit 1
+# 4. --apply without --yes-i-mean-it → exit 1
+# 5. --dry-run default when neither mode flag set
+# 6. --help prints usage (sed-extracted)
+# 7. Dry-run with fake gh produces plan + no mutations
+# 8. Label derivation from Trigger table row (via fake gh issue view)
+# 9. Private repo without 'repo' scope → exit 3 with scope hint
+# 10. Missing gh → exit 2
+
+set +e
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/error-reporter/scripts/retroactive-5axis.sh"
+
+PASS=0
+FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+[ -x "$SCRIPT" ] || { echo "FATAL: script not executable: $SCRIPT" >&2; exit 1; }
+
+# Helper: build a TD with fake gh that serves canned responses
+setup_fake_gh() {
+  local td="$1"
+  local mode="$2"    # "auth_ok_issue_public" | "auth_ok_issue_private_no_scope" | "auth_fail" | "mutate_capture"
+  mkdir -p "$td/bin"
+  case "$mode" in
+    auth_ok_issue_public)
+      cat > "$td/bin/gh" <<'GHFAKE'
+#!/bin/bash
+case "$1" in
+  auth)
+    case "$2" in
+      status) exit 0 ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  repo) echo 'false' ;;    # isPrivate=false
+  issue)
+    case "$2" in
+      view)
+        # Canned body with a Trigger table row — exercises the label parser
+        cat <<'BODY'
+## Trigger
+
+| Event | Hook | Phase | Agent | Severity | Commit |
+|-------|------|-------|-------|----------|--------|
+| `SubagentStop` | `pre-edit-guard.sh` | `verifying` | `editor` | `A2-guard-recovered` | `abc12345` |
+
+## Counterfactual
+Should have blocked earlier.
+BODY
+        ;;
+      edit)
+        printf 'FAKE_GH: %s\n' "$*" >> "$GH_CAPTURE"
+        exit 0
+        ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+GHFAKE
+      ;;
+    auth_ok_issue_private_no_scope)
+      cat > "$td/bin/gh" <<'GHFAKE'
+#!/bin/bash
+case "$1" in
+  auth)
+    case "$2" in
+      status)
+        # Pretend scope check shows only 'public_repo' (no 'repo')
+        echo "Logged in: public_repo" >&2
+        exit 0
+        ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  repo) echo 'true' ;;    # isPrivate=true
+  *) exit 0 ;;
+esac
+GHFAKE
+      ;;
+    auth_fail)
+      cat > "$td/bin/gh" <<'GHFAKE'
+#!/bin/bash
+case "$1" in
+  auth) exit 1 ;;
+  *) exit 1 ;;
+esac
+GHFAKE
+      ;;
+  esac
+  chmod +x "$td/bin/gh"
+}
+
+# --- Case 1: no args → exit 1 ---
+OUT=$("$SCRIPT" 2>&1)
+RC=$?
+[ "$RC" -eq 1 ] && pass "Case 1 no args → exit 1" || fail "Case 1 exit $RC"
+printf '%s' "$OUT" | grep -q "issues.*required" \
+  && pass "Case 1 stderr mentions --issues required" \
+  || fail "Case 1 missing --issues hint"
+
+# --- Case 2: malformed --issues ---
+OUT=$("$SCRIPT" --issues "malformed" 2>&1)
+RC=$?
+[ "$RC" -eq 1 ] && pass "Case 2 malformed --issues → exit 1" || fail "Case 2 exit $RC"
+printf '%s' "$OUT" | grep -q "owner/repo" \
+  && pass "Case 2 stderr shows expected format" \
+  || fail "Case 2 format hint missing"
+
+# --- Case 3: --apply without --yes-i-mean-it ---
+OUT=$("$SCRIPT" --apply --issues "test/repo:1" 2>&1)
+RC=$?
+[ "$RC" -eq 1 ] && pass "Case 3 --apply without --yes → exit 1" || fail "Case 3 exit $RC"
+printf '%s' "$OUT" | grep -q "yes-i-mean-it" \
+  && pass "Case 3 confirmation hint present" \
+  || fail "Case 3 hint missing"
+
+# --- Case 4: --help → exit 0 + usage ---
+OUT=$("$SCRIPT" --help 2>&1)
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 4 --help → exit 0" || fail "Case 4 --help exit $RC"
+printf '%s' "$OUT" | grep -q "Usage" \
+  && pass "Case 4 --help shows Usage" \
+  || fail "Case 4 --help missing Usage"
+
+# --- Case 5: auth fail → exit 2 ---
+TD=$(mktemp -d "/tmp/retro5-XXXXXX")
+setup_fake_gh "$TD" auth_fail
+OUT=$(PATH="$TD/bin:$PATH" "$SCRIPT" --dry-run --issues "test/repo:1" 2>&1)
+RC=$?
+[ "$RC" -eq 2 ] && pass "Case 5 auth fail → exit 2" || fail "Case 5 auth-fail exit $RC"
+printf '%s' "$OUT" | grep -q "not authenticated" \
+  && pass "Case 5 auth-fail hint present" \
+  || fail "Case 5 auth-fail hint missing"
+rm -rf "$TD"
+
+# --- Case 6: private repo without repo scope → exit 3 ---
+TD=$(mktemp -d "/tmp/retro5-XXXXXX")
+setup_fake_gh "$TD" auth_ok_issue_private_no_scope
+OUT=$(PATH="$TD/bin:$PATH" "$SCRIPT" --dry-run --issues "test/privateRepo:1" 2>&1)
+RC=$?
+[ "$RC" -eq 3 ] && pass "Case 6 private repo w/o 'repo' scope → exit 3" \
+  || fail "Case 6 private-scope exit $RC"
+printf '%s' "$OUT" | grep -q "repo" \
+  && pass "Case 6 scope hint mentions 'repo' scope" \
+  || fail "Case 6 scope hint missing"
+rm -rf "$TD"
+
+# --- Case 7: dry-run produces plan from canned Trigger table body ---
+TD=$(mktemp -d "/tmp/retro5-XXXXXX")
+setup_fake_gh "$TD" auth_ok_issue_public
+OUT=$(PATH="$TD/bin:$PATH" "$SCRIPT" --dry-run --issues "test/pubRepo:1" --sleep 0 2>&1)
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 7 dry-run exit 0" || fail "Case 7 dry-run exit $RC"
+# Expected labels from canned body:
+#   reporter:hook:pre-edit-guard   (stem, .sh stripped)
+#   reporter:phase:verifying
+#   reporter:severity:A2-guard-recovered
+#   reporter:cluster:<sha1 of "pre-edit-guard:verifying:A2-guard-recovered:editor">[:12]
+#   reporter:repo:test__pubRepo
+#   reporter:agent:editor
+for expect in \
+  "reporter:hook:pre-edit-guard" \
+  "reporter:phase:verifying" \
+  "reporter:severity:A2-guard-recovered" \
+  "reporter:cluster:" \
+  "reporter:repo:test__pubRepo" \
+  "reporter:agent:editor"; do
+  if printf '%s' "$OUT" | grep -q "$expect"; then
+    pass "Case 7 dry-run plan contains: $expect"
+  else
+    fail "Case 7 dry-run plan missing: $expect"
+  fi
+done
+rm -rf "$TD"
+
+# --- Case 8: apply+yes mutates (captures) ---
+TD=$(mktemp -d "/tmp/retro5-XXXXXX")
+setup_fake_gh "$TD" auth_ok_issue_public
+GH_CAPTURE="$TD/gh-calls.log"
+touch "$GH_CAPTURE"
+PATH="$TD/bin:$PATH" GH_CAPTURE="$GH_CAPTURE" \
+  "$SCRIPT" --apply --yes-i-mean-it --issues "test/pubRepo:1,2" --sleep 0 >/dev/null 2>&1
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 8 --apply+yes exit 0" || fail "Case 8 --apply exit $RC"
+# Should record 2 edit calls (one per issue). Capture log line shape:
+#   FAKE_GH: issue edit <N> --repo <...> --add-label <csv>
+# Grep for 'issue edit ' to match the distinct invocations.
+EDIT_CALLS=$(grep -c 'issue edit ' "$GH_CAPTURE" 2>/dev/null)
+EDIT_CALLS="${EDIT_CALLS:-0}"
+[ "$EDIT_CALLS" -eq 2 ] && pass "Case 8 captured 2 edit calls (one per issue)" \
+  || fail "Case 8 expected 2 edit calls, got $EDIT_CALLS"
+rm -rf "$TD"
+
+# --- Case 9: --sleep override works (0 sec → fast) ---
+# No explicit timing assertion — just verify the flag doesn't break parsing
+TD=$(mktemp -d "/tmp/retro5-XXXXXX")
+setup_fake_gh "$TD" auth_ok_issue_public
+OUT=$(PATH="$TD/bin:$PATH" "$SCRIPT" --dry-run --issues "test/pubRepo:1" --sleep 0 2>&1)
+RC=$?
+[ "$RC" -eq 0 ] && pass "Case 9 --sleep 0 accepted" || fail "Case 9 --sleep exit $RC"
+printf '%s' "$OUT" | grep -q "sleep-per-issue: 0s" \
+  && pass "Case 9 sleep value echoed in header" \
+  || fail "Case 9 sleep value not shown"
+rm -rf "$TD"
+
+printf '\nSummary: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

User-local operator tool that backfills the 5-axis labels (#22) onto historical `auto:hook-failure` issues filed BEFORE the schema rollout. Primary target: pmmm114/claude-harness-engineering smoke fixtures **#82 / #83 / #84** which currently carry only the legacy `reporter:domain:*` axis.

Intentionally NOT wired into CI — cross-repo label writes require a user PAT with `repo` scope, and the default `GITHUB_TOKEN` in a workflow context is repo-scoped (would 403 silently on writes to a different owner/repo).

## Changes

### `scripts/retroactive-5axis.sh` (new, ~250 lines)

**Safety-first CLI**

| Flag | Default | Effect |
|------|:-------:|--------|
| `--dry-run` | ✓ | Plans without writing |
| `--apply` | — | Writes (requires `--yes-i-mean-it`) |
| `--yes-i-mean-it` | — | Explicit confirmation for `--apply` |
| `--issues <owner/repo>:<n1,n2>` | — | **Required**; comma-separated issue numbers |
| `--remove-old-domain` | false | Destructive: strips existing `reporter:domain:*` after adding 5-axis |
| `--sleep <n>` | 2 | Per-issue pacing (rate-limit-safe) |

**Pre-flight validation**
- `gh auth status` check (exit 2 if not authenticated)
- Repo reachability + `isPrivate` detection via `gh repo view`
- For private repos: validates PAT has `repo` scope, else exit 3 with `gh auth refresh -s repo` hint

**Label derivation**
- Parses each issue's Trigger table (#24 body shape)
- Derives the SAME 5-axis labels using the SAME hash recipe as `scripts/report.sh` `_five_axis_labels` (sha1 over `hook:phase:severity:agent`, truncated 12 chars)
- Skips issues with legacy body shape (emits "could not derive — legacy format?")

**Rate-limit pacing**: 2-second sleep between issue edits (override via `--sleep`). GitHub core rate limit is 5000/hour, but the search-backed issue-list path has a stricter 30/min cap; 2s pacing stays well under both.

### `tests/unit_retroactive_5axis.sh` (new, 23 assertions across 9 cases)

| Case | Verifies |
|-----:|----------|
| 1 | No args → exit 1 + stderr hint |
| 2 | Malformed `--issues` → exit 1 + format example |
| 3 | `--apply` without `--yes-i-mean-it` → exit 1 + confirmation hint |
| 4 | `--help` → exit 0 + Usage text |
| 5 | Auth fail → exit 2 + "not authenticated" hint |
| 6 | Private repo without `repo` scope → exit 3 + `gh auth refresh` hint |
| 7 | Dry-run plan contains all 6 derived labels (hook stem / phase / severity / cluster / repo / agent) |
| 8 | `--apply --yes-i-mean-it` captures 2 edit calls via fake-gh |
| 9 | `--sleep <n>` override parsed and echoed |

Uses a canned fake `gh` on PATH that serves a Trigger-table body for the `view` subcommand and captures `edit` call args for the `edit` subcommand.

### `.github/workflows/tests.yml`

Adds `unit_retroactive_5axis.sh` as a CI step.

## Operational flow (for maintainer)

```bash
# One-time: refresh PAT scope for private repo writes
gh auth refresh -s repo

# Preview the plan
bash error-reporter/scripts/retroactive-5axis.sh \
     --dry-run \
     --issues pmmm114/claude-harness-engineering:82,83,84

# After reviewing, apply
bash error-reporter/scripts/retroactive-5axis.sh \
     --apply --yes-i-mean-it \
     --issues pmmm114/claude-harness-engineering:82,83,84
```

Add `--remove-old-domain` only after confirming the 5-axis additions look correct — this is destructive.

## Test Plan

```
bash error-reporter/tests/unit_retroactive_5axis.sh  # → 23 passed (new)
# plus all prior suites unchanged — grand total: 199 passed, 0 failed

shellcheck --severity=warning error-reporter/scripts/retroactive-5axis.sh error-reporter/tests/unit_retroactive_5axis.sh
# → 0 warnings
```

## Related

- Part of #22 (5-axis labels) follow-up set per v4 master plan
- Rides on #32 (5-axis emission logic — this script mirrors its hash recipe for consistency)
- Intentional: does not touch CI-writable paths; cross-repo writes happen only when user runs locally with adequate PAT scope
- Does not affect branch ruleset (#27) — no workflow policy changes