### PR TITLE
feat(error-reporter): populate ## Base Rates section with session-local ratio (#40)

### DIFF
--- a/error-reporter/scripts/report.sh
+++ b/error-reporter/scripts/report.sh
@@ -774,6 +774,57 @@ AGENT_FIELD="$AGENT_ID"
 
   TITLE="[incident] $EVENT${AGENT_ID:+($AGENT_ID)} (${SESSION:0:8})"
 
+  # F5 (#40): session-local base rate for TRIGGER_HOOK.
+  # deny/total ratio over this session's debug log (already at $LOG_FILE).
+  # Purely local computation — no cross-repo reads by default. Optional
+  # git-log enrichment gated behind ERROR_REPORTER_BASE_RATES_INCLUDE_GIT=true.
+  #
+  # IMPORTANT: TRIGGER_HOOK is the EXTRACTED name (via PRESET_HOOK_EXTRACT_JQ
+  # which may capture from `.reason` per P0-1). To count correctly we must
+  # compare against the SAME extraction on each log entry — otherwise, when
+  # the preset uses reason-prefix extraction, `.hook` in the log carries the
+  # library wrapper ("hook-lib.sh") while TRIGGER_HOOK is the guard name.
+  BASE_RATES_TEXT="(no hook context — skipping base-rate calculation)"
+  if [ -n "$TRIGGER_HOOK" ] && [ -n "$LOG_FILE" ] && [ -f "$LOG_FILE" ] \
+     && [ -n "$PRESET_HOOK_EXTRACT_JQ" ]; then
+    BR_TOTAL=$(jq -c --arg h "$TRIGGER_HOOK" \
+      "select($PRESET_HOOK_EXTRACT_JQ == \$h)" "$LOG_FILE" 2>/dev/null \
+      | wc -l | tr -d ' ')
+    BR_DENY=$(jq -c --arg h "$TRIGGER_HOOK" \
+      "select($PRESET_HOOK_EXTRACT_JQ == \$h) | select(.decision == \"deny\" or .decision == \"block\")" \
+      "$LOG_FILE" 2>/dev/null | wc -l | tr -d ' ')
+    BR_TOTAL=${BR_TOTAL:-0}
+    BR_DENY=${BR_DENY:-0}
+    if [ "$BR_TOTAL" -gt 0 ]; then
+      BR_ALLOW=$((BR_TOTAL - BR_DENY))
+      BR_PCT=$(awk -v d="$BR_DENY" -v t="$BR_TOTAL" 'BEGIN { printf "%.1f", (d * 100.0) / t }')
+      BASE_RATES_TEXT="\`$TRIGGER_HOOK\` fired **$BR_TOTAL time(s)** this session (**$BR_DENY deny** / $BR_ALLOW allow — **${BR_PCT}% deny**)"
+    else
+      BASE_RATES_TEXT="(no prior activity for \`$TRIGGER_HOOK\` this session)"
+    fi
+  fi
+
+  # Optional: git-log enrichment (5 most recent commits touching the hook file).
+  # Read-only access to $CLAUDE_CONFIG_DIR — not a HG-5 crossing (governs writes).
+  # Gated behind env opt-in so default behavior stays narrow.
+  if [ "${ERROR_REPORTER_BASE_RATES_INCLUDE_GIT:-false}" = "true" ] && [ -n "$TRIGGER_HOOK" ]; then
+    BR_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude-harness}"
+    BR_HOOK_PATH="hooks/$TRIGGER_HOOK"
+    if [ -f "$BR_CONFIG_DIR/$BR_HOOK_PATH" ] \
+       && git -C "$BR_CONFIG_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+      BR_RECENT=$(git -C "$BR_CONFIG_DIR" log --oneline -5 -- "$BR_HOOK_PATH" 2>/dev/null)
+      if [ -n "$BR_RECENT" ]; then
+        BASE_RATES_TEXT="$BASE_RATES_TEXT
+
+Recent commits on \`$BR_HOOK_PATH\`:
+
+\`\`\`
+$BR_RECENT
+\`\`\`"
+      fi
+    fi
+  fi
+
   # #24: extract the decisive entry — the first deny/fail line from the
   # last 50 lines of the debug log — with ±5 lines of context for signal
   # concentration. Falls back to the full tail when no match is found.
@@ -820,8 +871,7 @@ ${DECISIVE_CONTEXT}
 
 ## Base Rates
 
-<!-- TODO #24 follow-up: deny/total ratio for \`${TRIGGER_HOOK:-unknown}\`
-     + recent 5 commits on touched component. Requires harness repo access. -->
+${BASE_RATES_TEXT}
 
 ## Related Meta-Eval
 

--- a/error-reporter/tests/end_to_end_test.sh
+++ b/error-reporter/tests/end_to_end_test.sh
@@ -782,6 +782,76 @@ else
 fi
 cleanup_session "$SID" "$TD"
 
+# --- Test 17: Base Rates section populated with session-local deny/total ratio (#40 / F5) ---
+printf '\nTest 17: Base Rates section shows deny/total ratio for TRIGGER_HOOK\n'
+TD=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+SID="smoke-t17-$$-$(date +%s)"
+mkdir -p "$TD/markers"
+touch "$TD/markers/.v3.1-opt-in-notice.ack"
+
+# Seed a debug log with 10 entries for verify-before-done guard: 4 deny + 6 allow.
+# Real harness sets `.reason = "[sid:x] [hook.sh] ..."` on both deny and allow
+# decisions, so extraction produces the SAME hook name for both. Expected
+# base rate: 40.0% deny.
+mkdir -p /tmp/claude-debug
+{
+  for i in 1 2 3 4; do
+    printf '{"ts":"t%d","event":"PreToolUse","hook":"pre-edit-guard.sh","decision":"deny","reason":"[sid:x] [verify-before-done.sh] blocked","phase":"verifying","session":"%s"}\n' "$i" "$SID"
+  done
+  for i in 5 6 7 8 9 10; do
+    printf '{"ts":"t%d","event":"PreToolUse","hook":"pre-edit-guard.sh","decision":"allow","reason":"[sid:x] [verify-before-done.sh] ok","phase":"executing","session":"%s"}\n' "$i" "$SID"
+  done
+} > "/tmp/claude-debug/$SID.jsonl"
+
+INPUT=$(printf '{"hook_event_name":"SubagentStop","session_id":"%s","cwd":"","agent_id":"editor"}' "$SID")
+CLAUDE_PLUGIN_DATA="$TD" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+  ERROR_REPORTER_PRESET=claude-harness ERROR_REPORTER_REPO=dummy/repo \
+  bash -c "printf '%s' '$INPUT' | bash '$SCRIPT'"
+wait_for_background "$SID" "$TD/markers"
+
+FALLBACK_FILE=$(ls "$TD/reports/${SID}-"*".md" 2>/dev/null | head -1)
+if [ -n "$FALLBACK_FILE" ] && [ -f "$FALLBACK_FILE" ]; then
+  grep -qF '## Base Rates' "$FALLBACK_FILE" \
+    && pass "T17 Base Rates section header present" \
+    || fail "T17 Base Rates header missing"
+  grep -qE 'fired \*\*10 time\(s\)\*\*' "$FALLBACK_FILE" \
+    && pass "T17 Base Rates shows total count (10)" \
+    || fail "T17 Base Rates total count wrong"
+  grep -qE '\*\*4 deny\*\*' "$FALLBACK_FILE" \
+    && pass "T17 Base Rates shows deny count (4)" \
+    || fail "T17 Base Rates deny count wrong"
+  grep -qE '\*\*40\.0% deny\*\*' "$FALLBACK_FILE" \
+    && pass "T17 Base Rates shows percentage (40.0%)" \
+    || fail "T17 Base Rates percentage wrong"
+  if grep -qF 'Recent commits on' "$FALLBACK_FILE"; then
+    fail "T17 git enrichment appeared without env opt-in"
+  else
+    pass "T17 git enrichment correctly gated off (env unset)"
+  fi
+else
+  fail "T17 no fallback .md"
+fi
+cleanup_session "$SID" "$TD"
+
+# --- Test 17b: empty debug log → Base Rates does not crash the script ---
+printf '\nTest 17b: Base Rates handles empty debug log gracefully\n'
+TD=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+SID="smoke-t17b-$$-$(date +%s)"
+mkdir -p "$TD/markers"
+touch "$TD/markers/.v3.1-opt-in-notice.ack"
+
+mkdir -p /tmp/claude-debug
+: > "/tmp/claude-debug/$SID.jsonl"
+
+INPUT=$(printf '{"hook_event_name":"SubagentStop","session_id":"%s","cwd":"","agent_id":"editor"}' "$SID")
+CLAUDE_PLUGIN_DATA="$TD" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+  ERROR_REPORTER_PRESET=claude-harness ERROR_REPORTER_REPO=dummy/repo \
+  bash -c "printf '%s' '$INPUT' | bash '$SCRIPT'" 2>/dev/null
+RC=$?
+[ "$RC" -eq 0 ] && pass "T17b empty debug log does not crash the script" \
+  || fail "T17b empty log crashed exit $RC"
+cleanup_session "$SID" "$TD"
+
 # --- Test 15b: reporter:repo:* flatten handles underscores in owner/repo (#33) ---
 # The previous tr+sed transform misfired when owner or repo names contained
 # underscores. This test locks in the corrected behavior across three cases.


### PR DESCRIPTION
## Summary

Closes #40. Replaces the `## Base Rates` TODO placeholder (shipped in #35) with a real deny/total ratio computed from the current session's debug log. Gives the reviewer an immediate "is this a one-off or routine deny?" signal right in the issue body.

Purely local — no cross-repo reads by default. Optional git-log enrichment gated behind an env var.

## Design notes

### Why `PRESET_HOOK_EXTRACT_JQ` instead of raw `.hook`

This is load-bearing. When a preset opts into reason-prefix extraction (which the shipped `claude-harness` preset does per P0-1), `.hook` in the JSONL log holds the library wrapper (`hook-lib.sh`) while the actual firing guard name lives in `.reason`'s bracket. Counting by `.hook` would miscount every time the hook-lib drift is active.

So: use the SAME extraction expression for `select()` that the deny filter uses to populate `TRIGGER_HOOK`. Invariant: `TRIGGER_HOOK` == extracted value of at least one log entry. Matching counts must use the same extraction.

### Why `.reason` matters for the denominator

Real harness `hook-lib-core.sh` sets `.reason = "[sid:x] [guard.sh] ..."` on BOTH deny AND allow decisions. So the extraction yields the same guard name for both paths, and the denominator (total invocations of that guard this session) is accurate.

If a preset's hook_extraction is configured BUT some log lines lack `.reason` (e.g., an older harness version), those lines fall back to `.hook` via the jq fallback — which may NOT match the reason-extracted `TRIGGER_HOOK`, and will be excluded from the count. That's a latent environment-specific accuracy degradation rather than a correctness bug; documented in the code comment.

### Git-log enrichment off by default

Gated behind `ERROR_REPORTER_BASE_RATES_INCLUDE_GIT=true`:

- Reads `$CLAUDE_CONFIG_DIR/hooks/<hook>.sh` commit history (5 most recent)
- READ-ONLY access to `$CLAUDE_CONFIG_DIR`. HG-5 governs writes; reads of the shared harness config are allowed.
- Off by default so default body size stays bounded and operator control is explicit.

## Changes

**`scripts/report.sh`** (+54 / -2, in the fork subshell before `REPORT_BODY` construction)

```bash
BASE_RATES_TEXT="(no hook context — skipping base-rate calculation)"
if [ -n "$TRIGGER_HOOK" ] && [ -n "$LOG_FILE" ] && [ -f "$LOG_FILE" ] \
   && [ -n "$PRESET_HOOK_EXTRACT_JQ" ]; then
  BR_TOTAL=$(jq -c --arg h "$TRIGGER_HOOK" \
    "select($PRESET_HOOK_EXTRACT_JQ == \$h)" "$LOG_FILE" ...)
  BR_DENY=$(jq -c --arg h "$TRIGGER_HOOK" \
    "select($PRESET_HOOK_EXTRACT_JQ == \$h) | select(.decision == \"deny\" or .decision == \"block\")" ...)
  ...
  BASE_RATES_TEXT="\`$TRIGGER_HOOK\` fired **$BR_TOTAL time(s)** this session (**$BR_DENY deny** / $BR_ALLOW allow — **${BR_PCT}% deny**)"
fi

# Optional git-log enrichment (env-gated)
if [ "${ERROR_REPORTER_BASE_RATES_INCLUDE_GIT:-false}" = "true" ] && ...; then
  BR_RECENT=$(git -C "$BR_CONFIG_DIR" log --oneline -5 -- "$BR_HOOK_PATH" ...)
  BASE_RATES_TEXT="$BASE_RATES_TEXT\n\nRecent commits on \`$BR_HOOK_PATH\`:\n\`\`\`\n$BR_RECENT\n\`\`\`"
fi
```

Body template replacement:

```diff
-<!-- TODO #24 follow-up: deny/total ratio for `${TRIGGER_HOOK:-unknown}`
-     + recent 5 commits on touched component. Requires harness repo access. -->
+${BASE_RATES_TEXT}
```

**`tests/end_to_end_test.sh`** (+70 lines, 6 new assertions)

| Test | Assertions |
|------|-----------:|
| T17 | 5 — section header present, total=10, deny=4, percentage=40.0%, git enrichment gated off by default |
| T17b | 1 — empty debug log does not crash the script |

## Test Plan

```
bash error-reporter/tests/end_to_end_test.sh          # → 89 passed (+6 from 83)
bash error-reporter/tests/unit_preset_helpers.sh      # → 17 passed (unchanged)
bash error-reporter/tests/verify_preset_equivalence.sh # →  9 passed (unchanged)
bash error-reporter/tests/unit_resolve_repo.sh        # → 24 passed (unchanged)
bash error-reporter/tests/unit_incident_to_eval.sh    # → 17 passed (unchanged)
bash error-reporter/tests/unit_ensure_labels.sh       # → 26 passed (unchanged)
bash error-reporter/tests/unit_retroactive_5axis.sh   # → 23 passed (unchanged)

find . -name "*.sh" -not -path "./.git/*" | xargs shellcheck --severity=warning
# → 0 warnings repo-wide
```

Grand total: **205 assertions, 0 failures**.

Example Base Rates output (from T17 fixture):

```
## Base Rates

`verify-before-done` fired **10 time(s)** this session (**4 deny** / 6 allow — **40.0% deny**)
```

## Related

- Closes #40
- Parent: T3.B (#24)
- Rides on: #35 (body 7-section structure with placeholder), #32 (5-axis labels — TRIGGER_HOOK comes from the same extraction path)
- Does not affect: #36 (incident-to-eval — its parser doesn't touch Base Rates section), F7 (#42), F8 (#43) — independent sections
- Does not modify branch ruleset (#27) — no CI policy change