### PR TITLE
feat(error-reporter): Related Meta-Eval + Known Drift Match sections (#42, #43)

### DIFF
--- a/error-reporter/scripts/report.sh
+++ b/error-reporter/scripts/report.sh
@@ -825,6 +825,74 @@ $BR_RECENT
     fi
   fi
 
+  # F7 (#42): Related Meta-Eval lookup.
+  # Read-only enumeration of $CLAUDE_CONFIG_DIR/benchmarks/meta-evals/*.json
+  # for an eval that matches TRIGGER_HOOK. Not a HG-5 crossing (reads only).
+  # Outputs one of: exact pointer, tag-related pointer, coverage-gap badge,
+  # or a diagnostic when the directory is unreachable.
+  RELATED_EVAL_TEXT="(no hook context — skipping meta-eval lookup)"
+  if [ -n "$TRIGGER_HOOK" ]; then
+    ME_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude-harness}/benchmarks/meta-evals"
+    HOOK_STEM="${TRIGGER_HOOK%.sh}"
+    if [ ! -d "$ME_DIR" ]; then
+      RELATED_EVAL_TEXT="(meta-eval directory unreachable — \`\$CLAUDE_CONFIG_DIR/benchmarks/meta-evals\` missing)"
+    elif [ -f "$ME_DIR/${HOOK_STEM}.json" ]; then
+      RELATED_EVAL_TEXT="Exact: \`benchmarks/meta-evals/${HOOK_STEM}.json\` — run via \`python3 benchmarks/run.py --tag hook:${HOOK_STEM}\`"
+    else
+      # Substring tag match: scan each .json for a "hook:<stem>" tag
+      ME_MATCH=""
+      for f in "$ME_DIR"/*.json; do
+        [ -f "$f" ] || continue
+        if grep -q "\"hook:${HOOK_STEM}\"" "$f" 2>/dev/null; then
+          ME_MATCH=$(basename "$f")
+          break
+        fi
+      done
+      if [ -n "$ME_MATCH" ]; then
+        RELATED_EVAL_TEXT="Related: \`benchmarks/meta-evals/${ME_MATCH}\` (tagged \`hook:${HOOK_STEM}\`)"
+      else
+        RELATED_EVAL_TEXT="**coverage-gap** — no meta-eval covers \`${TRIGGER_HOOK}\`. Scaffold via \`python3 error-reporter/scripts/incident-to-eval.py --issue <this-url>\`."
+      fi
+    fi
+  fi
+
+  # F8 (#43): Known Drift Match — grep $CLAUDE_CONFIG_DIR/CLAUDE.md
+  # §"Known drift & risks" for TRIGGER_HOOK references. Read-only; HG-5 safe.
+  # awk range extracts the section so matches outside the section don't leak.
+  KNOWN_DRIFT_TEXT="(no hook context — skipping drift check)"
+  if [ -n "$TRIGGER_HOOK" ]; then
+    DRIFT_MD="${CLAUDE_CONFIG_DIR:-$HOME/.claude-harness}/CLAUDE.md"
+    KD_STEM="${TRIGGER_HOOK%.sh}"
+    if [ ! -f "$DRIFT_MD" ]; then
+      KNOWN_DRIFT_TEXT="(\`CLAUDE.md\` unreachable at \`\$CLAUDE_CONFIG_DIR\` — cannot check drift.)"
+    else
+      # Extract the "## Known drift & risks" section (up to next H2)
+      KD_SECTION=$(awk '
+        /^## Known drift/ { in_sect = 1; next }
+        /^## / && in_sect { exit }
+        in_sect { print }
+      ' "$DRIFT_MD")
+      if [ -z "$KD_SECTION" ]; then
+        KNOWN_DRIFT_TEXT="(\`CLAUDE.md\` has no §\"Known drift & risks\" section.)"
+      else
+        # Match either bare stem or stem.sh; limit to 3 occurrences
+        KD_MATCHES=$(printf '%s\n' "$KD_SECTION" \
+          | grep -nE "\`${KD_STEM}\b|\`${TRIGGER_HOOK}\`" \
+          | head -3)
+        if [ -z "$KD_MATCHES" ]; then
+          KNOWN_DRIFT_TEXT="No references to \`${TRIGGER_HOOK}\` in \`CLAUDE.md\` §\"Known drift & risks\"."
+        else
+          KD_COUNT=$(printf '%s\n' "$KD_MATCHES" | wc -l | tr -d ' ')
+          KNOWN_DRIFT_TEXT="Found ${KD_COUNT} match(es) in \`CLAUDE.md\` §\"Known drift & risks\":
+
+\`\`\`
+$KD_MATCHES
+\`\`\`"
+        fi
+      fi
+    fi
+  fi
+
   # #24: extract the decisive entry — the first deny/fail line from the
   # last 50 lines of the debug log — with ±5 lines of context for signal
   # concentration. Falls back to the full tail when no match is found.
@@ -875,13 +943,11 @@ ${BASE_RATES_TEXT}
 
 ## Related Meta-Eval
 
-<!-- TODO #24 follow-up: pointer to \`benchmarks/meta-evals/${TRIGGER_HOOK%.*}.json\`
-     or \`coverage-gap\` badge. Requires harness \`benchmarks/meta-evals/\` enumeration. -->
+${RELATED_EVAL_TEXT}
 
 ## Known Drift Match
 
-<!-- TODO #24 follow-up: auto-grep \$CLAUDE_CONFIG_DIR/CLAUDE.md
-     §\"Known drift & risks\" for \`${TRIGGER_HOOK:-unknown}\` references. -->
+${KNOWN_DRIFT_TEXT}
 
 ## Reproduction
 

--- a/error-reporter/tests/end_to_end_test.sh
+++ b/error-reporter/tests/end_to_end_test.sh
@@ -852,6 +852,158 @@ RC=$?
   || fail "T17b empty log crashed exit $RC"
 cleanup_session "$SID" "$TD"
 
+# --- Test 18: Related Meta-Eval section (#42 / F7) ---
+# Populates ## Related Meta-Eval via read-only scan of
+# $CLAUDE_CONFIG_DIR/benchmarks/meta-evals/. Four branches:
+#   a. exact filename match
+#   b. tag substring match
+#   c. coverage-gap (nothing matches)
+#   d. directory unreachable
+printf '\nTest 18: Related Meta-Eval lookup — 4 branches\n'
+
+run_t18_case() {
+  local label="$1"
+  local fake_config_dir="$2"   # empty → unset CLAUDE_CONFIG_DIR
+  local expected_substr="$3"
+  local td sid
+  td=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+  sid="smoke-t18-${label}-$(date +%s%N)-$RANDOM"
+  mkdir -p "$td/markers"
+  touch "$td/markers/.v3.1-opt-in-notice.ack"
+  mkdir -p /tmp/claude-debug
+  {
+    printf '{"ts":"t1","event":"PreToolUse","hook":"pre-edit-guard.sh","decision":"deny","reason":"[sid:x] [verify-before-done.sh] blocked","phase":"verifying","session":"%s"}\n' "$sid"
+  } > "/tmp/claude-debug/$sid.jsonl"
+  local payload
+  payload=$(printf '{"hook_event_name":"SubagentStop","session_id":"%s","cwd":"","agent_id":"editor"}' "$sid")
+
+  if [ -n "$fake_config_dir" ]; then
+    CLAUDE_PLUGIN_DATA="$td" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_CONFIG_DIR="$fake_config_dir" \
+      ERROR_REPORTER_PRESET=claude-harness ERROR_REPORTER_REPO=dummy/repo \
+      bash -c "printf '%s' '$payload' | bash '$SCRIPT'"
+  else
+    CLAUDE_PLUGIN_DATA="$td" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+      bash -c "unset CLAUDE_CONFIG_DIR; export CLAUDE_PLUGIN_DATA='$td' CLAUDE_PLUGIN_ROOT='$PLUGIN_ROOT' ERROR_REPORTER_PRESET=claude-harness ERROR_REPORTER_REPO=dummy/repo; printf '%s' '$payload' | bash '$SCRIPT'"
+  fi
+  wait_for_background "$sid" "$td/markers"
+  local fb
+  fb=$(ls "$td/reports/${sid}-"*".md" 2>/dev/null | head -1)
+  if [ -n "$fb" ] && grep -qF "$expected_substr" "$fb"; then
+    pass "T18 ($label): found expected substring '$expected_substr'"
+  else
+    local actual
+    actual=$(awk '/^## Related Meta-Eval/{p=1} /^## Known Drift/{p=0} p' "$fb" 2>/dev/null | head -3)
+    fail "T18 ($label): expected '$expected_substr', section shows: $actual"
+  fi
+  cleanup_session "$sid" "$td"
+}
+
+# Case a: exact filename match
+T18_CFG=$(mktemp -d "/tmp/er-t18-cfg-XXXXXX")
+mkdir -p "$T18_CFG/benchmarks/meta-evals"
+echo '{"id":"verify-before-done","tags":[]}' > "$T18_CFG/benchmarks/meta-evals/verify-before-done.json"
+run_t18_case "exact" "$T18_CFG" "Exact: \`benchmarks/meta-evals/verify-before-done.json\`"
+rm -rf "$T18_CFG"
+
+# Case b: tag substring match
+T18_CFG=$(mktemp -d "/tmp/er-t18-cfg-XXXXXX")
+mkdir -p "$T18_CFG/benchmarks/meta-evals"
+echo '{"id":"other","tags":["hook:verify-before-done","rule:something"]}' > "$T18_CFG/benchmarks/meta-evals/other.json"
+run_t18_case "tag-match" "$T18_CFG" "Related: \`benchmarks/meta-evals/other.json\`"
+rm -rf "$T18_CFG"
+
+# Case c: coverage-gap
+T18_CFG=$(mktemp -d "/tmp/er-t18-cfg-XXXXXX")
+mkdir -p "$T18_CFG/benchmarks/meta-evals"
+echo '{"id":"unrelated","tags":["hook:something-else"]}' > "$T18_CFG/benchmarks/meta-evals/unrelated.json"
+run_t18_case "coverage-gap" "$T18_CFG" "**coverage-gap**"
+rm -rf "$T18_CFG"
+
+# Case d: directory unreachable
+run_t18_case "unreachable" "/tmp/nonexistent-$(date +%s)-$RANDOM" "meta-eval directory unreachable"
+
+# --- Test 19: Known Drift Match section (#43 / F8) ---
+# Populates ## Known Drift Match via awk-extracted §"Known drift & risks"
+# from $CLAUDE_CONFIG_DIR/CLAUDE.md, then grep for TRIGGER_HOOK references.
+printf '\nTest 19: Known Drift Match — 4 branches\n'
+
+run_t19_case() {
+  local label="$1"
+  local fake_config_dir="$2"
+  local expected_substr="$3"
+  local td sid
+  td=$(mktemp -d "/tmp/er-smoke-XXXXXX")
+  sid="smoke-t19-${label}-$(date +%s%N)-$RANDOM"
+  mkdir -p "$td/markers"
+  touch "$td/markers/.v3.1-opt-in-notice.ack"
+  mkdir -p /tmp/claude-debug
+  printf '{"ts":"t1","event":"PreToolUse","hook":"pre-edit-guard.sh","decision":"deny","reason":"[sid:x] [verify-before-done.sh] blocked","phase":"verifying","session":"%s"}\n' \
+    "$sid" > "/tmp/claude-debug/$sid.jsonl"
+  local payload
+  payload=$(printf '{"hook_event_name":"SubagentStop","session_id":"%s","cwd":"","agent_id":"editor"}' "$sid")
+
+  CLAUDE_PLUGIN_DATA="$td" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_CONFIG_DIR="$fake_config_dir" \
+    ERROR_REPORTER_PRESET=claude-harness ERROR_REPORTER_REPO=dummy/repo \
+    bash -c "printf '%s' '$payload' | bash '$SCRIPT'"
+  wait_for_background "$sid" "$td/markers"
+  local fb
+  fb=$(ls "$td/reports/${sid}-"*".md" 2>/dev/null | head -1)
+  if [ -n "$fb" ] && grep -qF "$expected_substr" "$fb"; then
+    pass "T19 ($label): found expected substring '$expected_substr'"
+  else
+    local actual
+    actual=$(awk '/^## Known Drift/{p=1} /^## Reproduction/{p=0} p' "$fb" 2>/dev/null | head -5)
+    fail "T19 ($label): expected '$expected_substr', section shows: $actual"
+  fi
+  cleanup_session "$sid" "$td"
+}
+
+# Case a: match found in §"Known drift"
+T19_CFG=$(mktemp -d "/tmp/er-t19-cfg-XXXXXX")
+cat > "$T19_CFG/CLAUDE.md" <<'CMD'
+# Harness CLAUDE.md
+
+## Something else
+
+Unrelated content.
+
+## Known drift & risks
+
+1. **`verify-before-done` races with editor agent** — flaky guard-check.
+2. Other unrelated issue.
+
+## Yet another section
+
+stuff
+CMD
+run_t19_case "match" "$T19_CFG" 'match(es) in `CLAUDE.md`'
+rm -rf "$T19_CFG"
+
+# Case b: section exists but no match for this hook
+T19_CFG=$(mktemp -d "/tmp/er-t19-cfg-XXXXXX")
+cat > "$T19_CFG/CLAUDE.md" <<'CMD'
+## Known drift & risks
+
+1. `unrelated-hook.sh` issue.
+CMD
+run_t19_case "no-match" "$T19_CFG" 'No references to'
+rm -rf "$T19_CFG"
+
+# Case c: no §"Known drift" section at all
+T19_CFG=$(mktemp -d "/tmp/er-t19-cfg-XXXXXX")
+cat > "$T19_CFG/CLAUDE.md" <<'CMD'
+# Harness CLAUDE.md
+
+## Overview
+
+Content without the Known drift header.
+CMD
+run_t19_case "section-absent" "$T19_CFG" 'no §"Known drift & risks" section'
+rm -rf "$T19_CFG"
+
+# Case d: CLAUDE.md unreachable
+run_t19_case "unreachable" "/tmp/nonexistent-$(date +%s)-$RANDOM" 'CLAUDE.md` unreachable'
+
 # --- Test 15b: reporter:repo:* flatten handles underscores in owner/repo (#33) ---
 # The previous tr+sed transform misfired when owner or repo names contained
 # underscores. This test locks in the corrected behavior across three cases.


### PR DESCRIPTION
## Summary

Closes **#42** and **#43**. Populates the two remaining TODO placeholders (`## Related Meta-Eval` and `## Known Drift Match`) in the error-reporter incident body. Together with #44 (Base Rates), the 7-section body from #35 is now **fully dynamic** — every non-raw section carries live data.

Both features do read-only scans of `$CLAUDE_CONFIG_DIR`. HG-5 governs writes (to prevent code/config track cross-contamination during evaluation); reads of the well-known shared config path are allowed and happen already in many hook scripts. See the boundary/goal/side-effect analysis in the issue bodies.

## Changes

### 1. `## Related Meta-Eval` (F7 — closes #42)

Scans `$CLAUDE_CONFIG_DIR/benchmarks/meta-evals/*.json` via shell glob + `grep` tag lookup. Three match tiers, then a fallback:

| Tier | Match | Output |
|------|-------|--------|
| 1 | `meta-evals/<hook-stem>.json` exists | `` Exact: `benchmarks/meta-evals/<stem>.json` `` + run command |
| 2 | Any `.json` tagged `"hook:<stem>"` | `` Related: `benchmarks/meta-evals/<name>.json` `` |
| 3 | No match | `**coverage-gap**` badge + CTA to `incident-to-eval.py` (#36) |
| — | Dir unreachable | Graceful diagnostic (no crash) |

### 2. `## Known Drift Match` (F8 — closes #43)

`awk` range-extracts the `## Known drift & risks` section from `$CLAUDE_CONFIG_DIR/CLAUDE.md`, then `grep -n` for `` `<hook-stem>` `` or `` `<hook>.sh` `` references within that section only. Max 3 matches. Four outcomes:

| Outcome | Output |
|---------|--------|
| Matches found | `` Found N match(es) in `CLAUDE.md` §"Known drift & risks" `` + fenced line-numbered matches |
| Section exists but no reference | `` No references to `<hook>` in `CLAUDE.md` §"Known drift & risks" `` |
| Section absent | `` (`CLAUDE.md` has no §"Known drift & risks" section) `` |
| CLAUDE.md unreachable | `` (`CLAUDE.md` unreachable at `$CLAUDE_CONFIG_DIR`) `` |

### Implementation detail

Both sections computed in the fork subshell BEFORE `REPORT_BODY` construction so they interpolate naturally into the existing Markdown template via `${RELATED_EVAL_TEXT}` / `${KNOWN_DRIFT_TEXT}`. Each output is bounded to ~200-600 bytes, so the 10KB body cap (#35) is not at risk.

## Test Plan

```
bash error-reporter/tests/end_to_end_test.sh         # → 97 passed (+8 from 89)
bash error-reporter/tests/unit_preset_helpers.sh     # → 17 passed (unchanged)
bash error-reporter/tests/verify_preset_equivalence.sh # →  9 passed (unchanged)
bash error-reporter/tests/unit_resolve_repo.sh       # → 24 passed (unchanged)
bash error-reporter/tests/unit_incident_to_eval.sh   # → 17 passed (unchanged)
bash error-reporter/tests/unit_ensure_labels.sh      # → 26 passed (unchanged)
bash error-reporter/tests/unit_retroactive_5axis.sh  # → 23 passed (unchanged)

find . -name "*.sh" -not -path "./.git/*" | xargs shellcheck --severity=warning
# → 0 warnings
```

Grand total: **213 assertions, 0 failures**.

**T18** (F7, 4 branches × 1 assertion) — exact / tag-match / coverage-gap / unreachable
**T19** (F8, 4 branches × 1 assertion) — match / no-match / section-absent / unreachable

Fixture pattern: temp `CLAUDE_CONFIG_DIR` per case with crafted `CLAUDE.md` and/or `benchmarks/meta-evals/*.json`. Run via `CLAUDE_CONFIG_DIR=...` env override.

## Boundary / goal / side-effects (per the issue bodies)

- **Boundary**: `$CLAUDE_CONFIG_DIR` **read-only**. No writes anywhere. Safe under HG-5 (which governs writes).
- **Goal**: Fill the last two TODO sections with actionable data so reviewers can decide without clicking away from the issue.
- **Side-effects**:
  - Body grows by ~200-600 bytes (10KB cap still holds)
  - Weak coupling to harness CLAUDE.md header spelling (`## Known drift`) — if the harness rewords that header, this grep misses. `awk` range is resilient to content changes within the section.
  - F7 reads `benchmarks/meta-evals/*.json` at every emission — O(meta-eval count) per incident. At current harness scale (~10 evals) this is <10ms. If the directory grows to hundreds, consider caching; out of scope here.

## Context

With this PR merged, the 7-section body from #35 has every non-raw section dynamic:

- `## Trigger` — static facts (Event / Hook / Phase / ...)
- `## Decisive Entry` — awk scan of last 50 debug lines + ±5 context
- `## Counterfactual` — author-filled (by design)
- `## Base Rates` — deny/total from session log (#44)
- **`## Related Meta-Eval` — this PR**
- **`## Known Drift Match` — this PR**
- `## Reproduction` — `/kb-harness --from-incident` literal

Remaining follow-up on kb-cc-plugin side: only **#41 (F6) test-driven inversion** which is complex and long-term — incident-to-eval MVP (#36) ships today as draft-only, which is correct per HG-9.

## Related

- Closes #42, #43
- Parent: T3.B (#24)
- Rides on: #35 (body shell), #44 (Base Rates — same pattern), #36 (coverage-gap fallback references incident-to-eval)
- Does not modify: branch ruleset (#27), CI workflows, harness repo
- Compatible with: #41 (F6), harness-engineering#98/99/102 (independent tracks)